### PR TITLE
storageos: Update CSI helpers to support new driver discovery

### DIFF
--- a/stable/storageos/Chart.yaml
+++ b/stable/storageos/Chart.yaml
@@ -1,5 +1,5 @@
 name: storageos
-version: 0.1.2
+version: 0.2.0
 description: Converged storage for containers
 appVersion: 1.0.0-rc5
 apiVersion: v1

--- a/stable/storageos/templates/daemonset_csi.yaml
+++ b/stable/storageos/templates/daemonset_csi.yaml
@@ -49,6 +49,10 @@ spec:
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
+          - "--mode=node-register"
+          - "--driver-requires-attachment=true"
+          - "--pod-info-mount-version=v1"
+          - "--kubelet-registration-path=/var/lib/kubelet/plugins/storageos/csi.sock"
         env:
           - name: ADDRESS
             value: /csi/csi.sock # plugin-dir is mounted at /csi
@@ -56,6 +60,7 @@ spec:
           - name: KUBE_NODE_NAME
             valueFrom:
               fieldRef:
+                apiVersion: v1
                 fieldPath: spec.nodeName
         volumeMounts:
           - name: plugin-dir
@@ -63,6 +68,9 @@ spec:
             # This is where kubelet.sock exists.
           - name: registrar-socket-dir
             mountPath: /var/lib/csi/sockets/
+          volumeMounts:
+          - name: registration-dir
+            mountPath: /registration
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -219,6 +227,10 @@ spec:
         hostPath:
           path: /var/lib/kubelet/device-plugins/
           type: DirectoryOrCreate
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins
+          type: Directory
       - name: kubelet-dir
         hostPath:
           path: /var/lib/kubelet

--- a/stable/storageos/values.yaml
+++ b/stable/storageos/values.yaml
@@ -13,17 +13,17 @@ initContainer:
 
 csiDriverRegistrar:
   repository: quay.io/k8scsi/driver-registrar
-  tag: v0.2.0
+  tag: v0.4.0
   pullPolicy: IfNotPresent
 
 csiExternalProvisioner:
   repository: quay.io/k8scsi/csi-provisioner
-  tag: v0.3.0
+  tag: v0.4.0
   pullPolicy: Always
 
 csiExternalAttacher:
   repository: quay.io/k8scsi/csi-attacher
-  tag: v0.3.0
+  tag: v0.4.0
   pullPolicy: Always
 
 rbacEnabled: true

--- a/stable/storageos/values.yaml
+++ b/stable/storageos/values.yaml
@@ -13,7 +13,7 @@ initContainer:
 
 csiDriverRegistrar:
   repository: quay.io/k8scsi/driver-registrar
-  tag: v0.4.0
+  tag: v0.4.1
   pullPolicy: IfNotPresent
 
 csiExternalProvisioner:


### PR DESCRIPTION
This updates the driver registrar container to support driver discovery
using kubelet plugin watcher.
It also updates the external provisioner and attacher to their latest
stable releases.
Bumping the chart version minor to 2 because the new driver registrar
will no longer work with kubernetes v1.11 and below without enabling
feature gate KubeletPluginsWatcher explicitly. This is in beta in k8s
v1.12 and is enabled by default.