### PR TITLE
Change secret namespace to storageos

### DIFF
--- a/stable/storageos/values.yaml
+++ b/stable/storageos/values.yaml
@@ -49,7 +49,7 @@ storageclass:
   fsType: ext4
 api:
   secretName: storageos-api
-  secretNamespace: default
+  secretNamespace: storageos
   # secrets are namespace specific, create 1+N for every namespace.
   address: storageos:5705
   # address is used to generate the ApiAddress value in the secret. This


### PR DESCRIPTION
PR to change the secret namespace to storageos. Given that it worked in the other helm repo this is a low risk change. 