### PR TITLE
storageos/storageos: Create secrets for CSI as well

### DIFF
--- a/stable/storageos/Chart.yaml
+++ b/stable/storageos/Chart.yaml
@@ -1,5 +1,5 @@
 name: storageos
-version: 0.2.6
+version: 0.2.7
 description: Converged storage for containers
 appVersion: 1.0.0-rc5
 apiVersion: v1

--- a/stable/storageos/templates/secrets.yaml
+++ b/stable/storageos/templates/secrets.yaml
@@ -1,5 +1,3 @@
-{{- if not .Values.csi.enable }}
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,5 +14,3 @@ data:
   apiAddress: {{ default "" .Values.api.address | b64enc | quote }}
   apiUsername: {{ default "" .Values.api.username | b64enc | quote }}
   apiPassword: {{ default "" .Values.api.password | b64enc | quote }}
-
-{{- end }}


### PR DESCRIPTION
CSI setup used to refer to the init-secret which was created
unconditionally. api-secret is created only for the non-CSI setup.
Since init-secret is removed now and api-secret has been moved to
the common namespace, it must be created always.