### PR TITLE
Add k8s chart version table

### DIFF
--- a/stable/storageos/Chart.yaml
+++ b/stable/storageos/Chart.yaml
@@ -1,5 +1,5 @@
 name: storageos
-version: 0.3.0
+version: 0.3.1
 description: Converged storage for containers
 appVersion: 1.1.0
 apiVersion: v1

--- a/stable/storageos/README-CSI.md
+++ b/stable/storageos/README-CSI.md
@@ -17,6 +17,14 @@ Features such as replication, encryption and caching help protect data and maxim
 
 Refer to the [StorageOS prerequisites docs](https://docs.storageos.com/docs/install/prerequisites/) for more information.
 
+| Kubernetes version     | Compatible Chart Version     |
+| ---------------------- | ---------------------------- |
+| 1.13                   | 0.3.x                        |
+| 1.12                   | 0.2.x                        |
+| 1.11                   | 0.1.x                        |
+| 1.10                   | 0.1.x                        |
+
+
 ## TL;DR
 
 ```console


### PR DESCRIPTION
Adding a table to show what chart version should be used with what K8s version specifically for the CSI installation. 

Will only be merged once @darkowlzz updates the operator. 