### PR TITLE
storageos chart v1.0.0 with PVC labels support

### DIFF
--- a/stable/storageos/Chart.yaml
+++ b/stable/storageos/Chart.yaml
@@ -1,5 +1,5 @@
 name: storageos
-version: 0.3.2
+version: 1.0.0
 description: Converged storage for containers
 appVersion: 1.1.1
 apiVersion: v1

--- a/stable/storageos/README-CSI.md
+++ b/stable/storageos/README-CSI.md
@@ -109,7 +109,7 @@ Parameter | Description | Default
 `csiNodeDriverRegistrar.repository` | CSI Node Driver Registrar container image repository | `quay.io/k8scsi/csi-node-driver-registrar`
 `csiNodeDriverRegistrar.tag` | CSI Node Driver Registrar container image tag | `v1.0.1`
 `csiNodeDriverRegistrar.pullPolicy` | CSI Node Driver Registrar container image pull policy | `IfNotPresent`
-`csiExternalProvisioner.repository` | CSI External Provisioner container image repository | `quay.io/k8scsi/csi-provisioner`
+`csiExternalProvisioner.repository` | CSI External Provisioner container image repository | `storageos/csi-provisioner`
 `csiExternalProvisioner.tag` | CSI External Provisioner container image tag | `v1.0.1`
 `csiExternalProvisioner.pullPolicy` | CSI External Provisioner container image pull policy | `Always`
 `csiExternalAttacher.repository` | CSI External Attacher container image repository | `quay.io/k8scsi/csi-attacher`

--- a/stable/storageos/values.yaml
+++ b/stable/storageos/values.yaml
@@ -22,7 +22,7 @@ csiNodeDriverRegistrar:
   pullPolicy: IfNotPresent
 
 csiExternalProvisioner:
-  repository: quay.io/k8scsi/csi-provisioner
+  repository: storageos/csi-provisioner
   tag: v1.0.1
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updates the csi-provisioner container image with a forked version that
supports PVC labels.