### PR TITLE
Use helmpack/chart-testing image with defer fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - K8S_VERSION="v1.13.2"
     # - MINIKUBE_VERSION="v0.28.2"
     - CHART_TESTING_IMAGE="storageos/chart-testing"
-    - CHART_TESTING_TAG="v2.1.0"
+    - CHART_TESTING_TAG="v2.1.0-defer-fix"
     - CHARTS_REPO="https://github.com/storageos/charts"
 
 before_install:

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -5,4 +5,3 @@ chart-dirs:
 # excluded-charts:
 #   - common
 helm-extra-args: --timeout 160
-run-single-values: true


### PR DESCRIPTION
Removes the forked changes and uses the original repo with delete
release fix.

Refer: https://github.com/helm/chart-testing/issues/83