### PR TITLE
Add explicit nodeImage version for install output.

### DIFF
--- a/stable/storageoscluster-operator/templates/NOTES.txt
+++ b/stable/storageoscluster-operator/templates/NOTES.txt
@@ -32,5 +32,10 @@ metadata:
 spec:
   secretRefName: storageos-api
   secretRefNamespace: default
+  images:
+    nodeContainer: "storageos/node:1.1.2" # StorageOS version
+  resources:
+    requests:
+    memory: "512Mi"
   csi:
     enable: true


### PR DESCRIPTION
With this change, the output of Helm install will give you an example to deploy the CR.yaml releasing the latest version of StorageOS. That output will be changed at StorageOS version bump. 
When the operator is built to reflect by default the latest StorageOS version, this change will be redundant.