### PR TITLE
StorageOS Operator v1 support

### DIFF
--- a/stable/storageoscluster-operator/Chart.yaml
+++ b/stable/storageoscluster-operator/Chart.yaml
@@ -1,12 +1,13 @@
 apiVersion: v1
-appVersion: "0.0.11"
+appVersion: "1.0.0"
 description: A StorageOS Cluster Operator chart for Kubernetes
 name: storageoscluster-operator
-version: 0.1.12
+version: 1.0.0
 keywords:
 - storage
 - block-storage
 - volume
+- operator
 home: https://storageos.com
 icon: https://storageos.com/wp-content/themes/storageOS/images/logo.svg
 sources:

--- a/stable/storageoscluster-operator/README.md
+++ b/stable/storageoscluster-operator/README.md
@@ -58,7 +58,7 @@ Create a `StorageOSCluster` custom resource and refer the above secret in
 `secretRefName` and `secretRefNamespace` fields.
 
 ```yaml
-apiVersion: "storageos.com/v1alpha1"
+apiVersion: "storageos.com/v1"
 kind: "StorageOSCluster"
 metadata:
   name: "example-storageos"
@@ -124,8 +124,8 @@ Operator chart and their default values.
 
 Parameter | Description | Default
 --------- | ----------- | -------
-`image.repository` | StorageOSCluster container image repository | `storageos/storageoscluster-operator`
-`image.tag` | StorageOSCluster container image tag | `v0.0.11`
+`image.repository` | StorageOSCluster container image repository | `storageos/cluster-operator`
+`image.tag` | StorageOSCluster container image tag | `v1.0.0`
 `image.pullPolicy` | StorageOSCluster container image pull policy | `IfNotPresent`
 
 

--- a/stable/storageoscluster-operator/templates/NOTES.txt
+++ b/stable/storageoscluster-operator/templates/NOTES.txt
@@ -24,7 +24,7 @@ data:
 above (storageos-api in the above example). When the resource is created, the
 cluster will be deployed.
 
-apiVersion: storageos.com/v1alpha1
+apiVersion: storageos.com/v1
 kind: StorageOSCluster
 metadata:
   name: example-storageos

--- a/stable/storageoscluster-operator/templates/job_crd.yaml
+++ b/stable/storageoscluster-operator/templates/job_crd.yaml
@@ -10,4 +10,4 @@ spec:
     plural: jobs
     singular: job
   scope: Namespaced
-  version: v1alpha1
+  version: v1

--- a/stable/storageoscluster-operator/templates/rbac.yaml
+++ b/stable/storageoscluster-operator/templates/rbac.yaml
@@ -36,6 +36,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - events
   - namespaces
   - serviceaccounts
@@ -66,6 +77,7 @@ rules:
   resources:
   - storageclasses
   - volumeattachments
+  - csinodeinfos
   verbs:
   - create
   - delete

--- a/stable/storageoscluster-operator/templates/storageoscluster_crd.yaml
+++ b/stable/storageoscluster-operator/templates/storageoscluster_crd.yaml
@@ -12,7 +12,7 @@ spec:
     shortNames:
     - stos
   scope: Namespaced
-  version: v1alpha1
+  version: v1
   additionalPrinterColumns:
   - name: Ready
     type: string
@@ -39,6 +39,10 @@ spec:
               type: string
             namespace:
               type: string
+            disableFencing:
+              type: boolean
+            disableTelemetry:
+              type: boolean
             images:
               properties:
                 nodeContainer:
@@ -88,8 +92,6 @@ spec:
                 tls:
                   type: boolean
                 annotations: {}
-            cleanupAtDelete:
-              type: boolean
             kvBackend:
               properties:
                 address:
@@ -101,6 +103,7 @@ spec:
             debug:
               type: boolean
             nodeSelectorTerms: {}
+            tolerations: {}
             resources:
               properties:
                 limits: {}

--- a/stable/storageoscluster-operator/templates/storageosupgrade_crd.yaml
+++ b/stable/storageoscluster-operator/templates/storageosupgrade_crd.yaml
@@ -10,4 +10,4 @@ spec:
     plural: storageosupgrades
     singular: storageosupgrade
   scope: Namespaced
-  version: v1alpha1
+  version: v1

--- a/stable/storageoscluster-operator/values.yaml
+++ b/stable/storageoscluster-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: storageos/cluster-operator
-  tag: v0.0.11
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
This sets chart version to 1.0.0 to avoid installing operator v1 if the previous version of the chart is updated.