### PR TITLE
cluster-operator: Add helm hook crd-install

### DIFF
--- a/stable/storageoscluster-operator/Chart.yaml
+++ b/stable/storageoscluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: A StorageOS Cluster Operator chart for Kubernetes
 name: storageoscluster-operator
-version: 1.0.1
+version: 1.0.2
 keywords:
 - storage
 - block-storage

--- a/stable/storageoscluster-operator/templates/job_crd.yaml
+++ b/stable/storageoscluster-operator/templates/job_crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: jobs.storageos.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: storageos.com
   names:

--- a/stable/storageoscluster-operator/templates/storageoscluster_crd.yaml
+++ b/stable/storageoscluster-operator/templates/storageoscluster_crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: storageosclusters.storageos.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: storageos.com
   names:

--- a/stable/storageoscluster-operator/templates/storageosupgrade_crd.yaml
+++ b/stable/storageoscluster-operator/templates/storageosupgrade_crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: storageosupgrades.storageos.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: storageos.com
   names:


### PR DESCRIPTION
`crd-install` helm hook ensures the CRDs are installed before a custom
resource.