### PR TITLE
storageos: Add CSI helper Deployment option

### DIFF
--- a/stable/storageos/Chart.yaml
+++ b/stable/storageos/Chart.yaml
@@ -1,7 +1,7 @@
 name: storageos
-version: 1.0.9
+version: 1.1.0
 description: Converged storage for containers
-appVersion: 1.2.0
+appVersion: 1.2.1
 apiVersion: v1
 keywords:
 - storage

--- a/stable/storageos/Chart.yaml
+++ b/stable/storageos/Chart.yaml
@@ -1,5 +1,5 @@
 name: storageos
-version: 1.0.8
+version: 1.0.9
 description: Converged storage for containers
 appVersion: 1.2.0
 apiVersion: v1

--- a/stable/storageos/LICENSE
+++ b/stable/storageos/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 StorageOS
+Copyright (c) 2019 StorageOS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/stable/storageos/README-CSI.md
+++ b/stable/storageos/README-CSI.md
@@ -120,7 +120,7 @@ Parameter | Description | Default
 `storageclass.fsType` | Default filesystem type for storage class | `ext4`
 `resources` | Pod resource requests & limits | `{}`
 `csi.enable` | Enable CSI driver installation | `false`
-`csi.helperDeployment` | CSI helper sidecar deployment option (`statefulset` or `deployment`) | `statefulset`
+`csi.deploymentStrategy` | CSI helper sidecar deployment strategy (`statefulset` or `deployment`) | `statefulset`
 `csi.provisionCreds.enable` | Enable credentials for volume provision operations | `false`
 `csi.provisionCreds.username` | Username for CSI provision operation authentication |
 `csi.provisionCreds.password` | Password for CSI provision operatiion authentication |

--- a/stable/storageos/README-CSI.md
+++ b/stable/storageos/README-CSI.md
@@ -120,6 +120,7 @@ Parameter | Description | Default
 `storageclass.fsType` | Default filesystem type for storage class | `ext4`
 `resources` | Pod resource requests & limits | `{}`
 `csi.enable` | Enable CSI driver installation | `false`
+`csi.helperDeployment` | CSI helper sidecar deployment option (`statefulset` or `deployment`) | `statefulset`
 `csi.provisionCreds.enable` | Enable credentials for volume provision operations | `false`
 `csi.provisionCreds.username` | Username for CSI provision operation authentication |
 `csi.provisionCreds.password` | Password for CSI provision operatiion authentication |

--- a/stable/storageos/ci/02-csi-values.yaml
+++ b/stable/storageos/ci/02-csi-values.yaml
@@ -1,6 +1,7 @@
 ---
 csi:
   enable: true
+  helperDeployment: deployment
   provisionCreds:
     enable: true
     username: username1

--- a/stable/storageos/ci/02-csi-values.yaml
+++ b/stable/storageos/ci/02-csi-values.yaml
@@ -1,7 +1,7 @@
 ---
 csi:
   enable: true
-  helperDeployment: deployment
+  deploymentStrategy: deployment
   provisionCreds:
     enable: true
     username: username1

--- a/stable/storageos/templates/csi_helpers.yaml
+++ b/stable/storageos/templates/csi_helpers.yaml
@@ -76,5 +76,16 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry/storageos/
             type: DirectoryOrCreate
+      # Add toleration for quicker termination of pod and recovery in case of a
+      # node failure.
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 
 {{- end }}

--- a/stable/storageos/templates/csi_helpers.yaml
+++ b/stable/storageos/templates/csi_helpers.yaml
@@ -1,6 +1,6 @@
-# Create csi-helper Deployment if CSI is enabled and csi.helperDeployment is
+# Create csi-helper Deployment if CSI is enabled and csi.deploymentStrategy is
 # "deployment".
-{{- if and .Values.csi.enable (eq .Values.csi.helperDeployment "deployment") }}
+{{- if and .Values.csi.enable (eq .Values.csi.deploymentStrategy "deployment") }}
 
 kind: Deployment
 apiVersion: apps/v1

--- a/stable/storageos/templates/csi_helpers.yaml
+++ b/stable/storageos/templates/csi_helpers.yaml
@@ -1,12 +1,11 @@
-# Create csi-helper StatefulSet if CSI is enabled and csi.helperDeployment is
-# not equal to "deployment". StatefulSet is the default for backwards
-# compatibility.
-{{- if and .Values.csi.enable (ne .Values.csi.helperDeployment "deployment") }}
+# Create csi-helper Deployment if CSI is enabled and csi.helperDeployment is
+# "deployment".
+{{- if and .Values.csi.enable (eq .Values.csi.helperDeployment "deployment") }}
 
-kind: StatefulSet
-apiVersion: apps/v1beta1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
-  name: {{ template "storageos.fullname" . }}-statefulset
+  name: {{ template "storageos.fullname" . }}-csi-helper
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "storageos.name" . }}
@@ -14,7 +13,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  serviceName: {{ .Chart.Name }}
   replicas: 1
   selector:
     matchLabels:
@@ -26,9 +24,9 @@ spec:
         chart: {{ template "storageos.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        kind: statefulset
+        kind: deployment
     spec:
-      serviceAccount: {{ template "storageos.fullname" . }}-statefulset-sa
+      serviceAccount: {{ template "storageos.fullname" . }}-csi-helper-sa
       containers:
       - name: csi-external-provisioner
         image: "{{ .Values.csiExternalProvisioner.repository }}:{{ .Values.csiExternalProvisioner.tag }}"

--- a/stable/storageos/templates/rolebinding.yaml
+++ b/stable/storageos/templates/rolebinding.yaml
@@ -45,7 +45,11 @@ subjects:
     name: {{ template "storageos.fullname" . }}-daemonset-sa
     namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
+    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    name: {{ template "storageos.fullname" . }}-csi-helper-sa
+    {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
+    {{- end }}
     namespace: {{ .Release.Namespace }}
   {{- else }}
   - kind: ServiceAccount

--- a/stable/storageos/templates/rolebinding.yaml
+++ b/stable/storageos/templates/rolebinding.yaml
@@ -45,7 +45,7 @@ subjects:
     name: {{ template "storageos.fullname" . }}-daemonset-sa
     namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
-    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    {{- if eq .Values.csi.deploymentStrategy "deployment" }}
     name: {{ template "storageos.fullname" . }}-csi-helper-sa
     {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa

--- a/stable/storageos/templates/setup_csi.yaml
+++ b/stable/storageos/templates/setup_csi.yaml
@@ -199,7 +199,7 @@ rules:
 
 ---
 
-{{- if eq .Values.csi.helperDeployment "deployment" }}
+{{- if eq .Values.csi.deploymentStrategy "deployment" }}
 
 # Service Account for CSI helper Deployment.
 kind: ServiceAccount
@@ -244,7 +244,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    {{- if eq .Values.csi.deploymentStrategy "deployment" }}
     name: {{ template "storageos.fullname" . }}-csi-helper-sa
     {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
@@ -269,7 +269,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    {{- if eq .Values.csi.deploymentStrategy "deployment" }}
     name: {{ template "storageos.fullname" . }}-csi-helper-sa
     {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
@@ -294,7 +294,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    {{- if eq .Values.csi.deploymentStrategy "deployment" }}
     name: {{ template "storageos.fullname" . }}-csi-helper-sa
     {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
@@ -319,7 +319,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    {{- if eq .Values.csi.deploymentStrategy "deployment" }}
     name: {{ template "storageos.fullname" . }}-csi-helper-sa
     {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa

--- a/stable/storageos/templates/setup_csi.yaml
+++ b/stable/storageos/templates/setup_csi.yaml
@@ -199,6 +199,23 @@ rules:
 
 ---
 
+{{- if eq .Values.csi.helperDeployment "deployment" }}
+
+# Service Account for CSI helper Deployment.
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "storageos.fullname" . }}-csi-helper-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+
+
+{{- else }}
+
 # Service Account for StorageOS StatefulSet.
 kind: ServiceAccount
 apiVersion: v1
@@ -211,9 +228,11 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 
+{{- end }}
+
 ---
 
-# Bind StatefulSet service account to External Provisioner role.
+# Bind CSI helper service account to External Provisioner role.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -225,7 +244,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
+    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    name: {{ template "storageos.fullname" . }}-csi-helper-sa
+    {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
+    {{- end }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -234,7 +257,7 @@ roleRef:
 
 ---
 
-# Bind StatefulSet service account to External Attacher role.
+# Bind CSI helper service account to External Attacher role.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -246,7 +269,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
+    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    name: {{ template "storageos.fullname" . }}-csi-helper-sa
+    {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
+    {{- end }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -255,7 +282,7 @@ roleRef:
 
 ---
 
-# Bind StatefulSet service account to Key Management role.
+# Bind CSI helper service account to Key Management role.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -267,7 +294,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
+    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    name: {{ template "storageos.fullname" . }}-csi-helper-sa
+    {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
+    {{- end }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -276,7 +307,7 @@ roleRef:
 
 ---
 
-# Binding Statefulset service account to Driver Registrar role.
+# Binding CSI helper service account to Driver Registrar role.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -288,7 +319,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
+    {{- if eq .Values.csi.helperDeployment "deployment" }}
+    name: {{ template "storageos.fullname" . }}-csi-helper-sa
+    {{- else }}
     name: {{ template "storageos.fullname" . }}-statefulset-sa
+    {{- end }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/stable/storageos/templates/statefulset_csi.yaml
+++ b/stable/storageos/templates/statefulset_csi.yaml
@@ -1,7 +1,7 @@
-# Create csi-helper StatefulSet if CSI is enabled and csi.helperDeployment is
+# Create csi-helper StatefulSet if CSI is enabled and csi.deploymentStrategy is
 # not equal to "deployment". StatefulSet is the default for backwards
 # compatibility.
-{{- if and .Values.csi.enable (ne .Values.csi.helperDeployment "deployment") }}
+{{- if and .Values.csi.enable (ne .Values.csi.deploymentStrategy "deployment") }}
 
 kind: StatefulSet
 apiVersion: apps/v1beta1

--- a/stable/storageos/values.yaml
+++ b/stable/storageos/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: storageos/node
-  tag: 1.2.0
+  tag: 1.2.1
   pullPolicy: IfNotPresent
 
 initContainer:

--- a/stable/storageos/values.yaml
+++ b/stable/storageos/values.yaml
@@ -137,6 +137,10 @@ ingress:
 
 csi:
   enable: false
+  # helperDeployment is the strategy used to deploy the CSI helpers. By default
+  # the helpers are deployed as StatefulSet for backwards compatibility. It can
+  # be set to "deployment" to deploy them as Deployment.
+  helperDeployment: statefulset
   version: v1
   # provisionCreds are credentials for volume create and delete operations.
   provisionCreds:

--- a/stable/storageos/values.yaml
+++ b/stable/storageos/values.yaml
@@ -137,10 +137,10 @@ ingress:
 
 csi:
   enable: false
-  # helperDeployment is the strategy used to deploy the CSI helpers. By default
-  # the helpers are deployed as StatefulSet for backwards compatibility. It can
-  # be set to "deployment" to deploy them as Deployment.
-  helperDeployment: statefulset
+  # deploymentStrategy is the strategy used to deploy the CSI helpers. By
+  # default the helpers are deployed as StatefulSet for backwards compatibility.
+  # It can be set to "deployment" to deploy them as Deployment.
+  deploymentStrategy: statefulset
   version: v1
   # provisionCreds are credentials for volume create and delete operations.
   provisionCreds:


### PR DESCRIPTION
This adds an option to deploy the CSI helper sidecars as Deployment,
keeping the default to StatefulSet.