### PR TITLE
storageos-operator: Sync with rancher chart

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.1.0"
+appVersion: "1.2.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.1.1
+version: 0.2.0
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -148,9 +148,9 @@ Operator chart and their default values.
 
 Parameter | Description | Default
 --------- | ----------- | -------
-`operator.image.repository` | StorageOSCluster container image repository | `storageos/cluster-operator`
-`operator.image.tag` | StorageOSCluster container image tag | `1.1.0`
-`operator.image.pullPolicy` | StorageOSCluster container image pull policy | `IfNotPresent`
+`operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
+`operator.image.tag` | StorageOS Operator container image tag | `1.2.0`
+`operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
 `podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
 `podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
 `cluster.create` | If true, auto-create the StorageOS cluster | `true`
@@ -173,6 +173,7 @@ Parameter | Description | Default
 `cluster.images.node.repository` | StorageOS Node container image repository | `storageos/node`
 `cluster.images.node.tag` | StorageOS Node container image tag | `1.2.0`
 `cluster.csi.enable` | If true, CSI driver is enabled | `true`
+`cluster.csi.deploymentStrategy` | Whether CSI helpers should be deployed as a `deployment` or `statefulset` | `deployment`
 
 ## Deleting a StorageOS Cluster
 

--- a/stable/storageos-operator/app-readme.md
+++ b/stable/storageos-operator/app-readme.md
@@ -16,4 +16,5 @@ configurations, disable the default installation of StorageOS and create a
 custom StorageOSCluster resource
 ([documentation](https://docs.storageos.com/docs/reference/cluster-operator/examples)).
 
-`Notes: StorageOS is required to be installed in System Project with Cluster Role`
+`Notes: The StorageOS Operator must be installed in the System Project with
+Cluster Role`

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -94,7 +94,7 @@ questions:
   - variable: cluster.disableTelemetry
     default: false
     type: boolean
-    description: "Disable telemetry to be collected from the cluster."
+    description: "Disable telemetry data collection.  See https://docs.storageos.com/docs/reference/telemetry for more information."
     label: Disable Telemetry
 
   # KV store backend.
@@ -127,8 +127,8 @@ questions:
   # Node Selector Term.
   - variable: cluster.nodeSelectorTerm.key
     required: false
-    default: "node-role.kubernetes.io/worker"
-    description: "Key of the node selector term match expression used to select the nodes to install StorageOS on."
+    default: ""
+    description: "Key of the node selector term match expression used to select the nodes to install StorageOS on, e.g. `node-role.kubernetes.io/worker`"
     type: string
     label: Node selector term key
   - variable: cluster.nodeSelectorTerm.value

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -32,7 +32,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "1.1.0"
+    default: "1.2.0"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -73,7 +73,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "1.2.0"
+    default: "1.2.1"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/stable/storageos-operator/templates/cleanup.yaml
+++ b/stable/storageos-operator/templates/cleanup.yaml
@@ -114,7 +114,7 @@ spec:
     spec:
       serviceAccountName: storageos-cleanup-sa
       containers:
-      - name: "statefulset-{{ .name }}-cleanup"
+      - name: "storageos-{{ .name }}-cleanup"
         image: bitnami/kubectl:1.14.1
         command:
           - kubectl
@@ -124,6 +124,7 @@ spec:
           {{- range .command }}
           - {{ . | quote }}
           {{- end }}
+          - --ignore-not-found=true
       restartPolicy: Never
   backoffLimit: 4
 

--- a/stable/storageos-operator/templates/cleanup.yaml
+++ b/stable/storageos-operator/templates/cleanup.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: storageos-cleanup-sa
-  namespace: {{ .Values.cluster.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed, before-hook-creation"
@@ -87,7 +87,7 @@ metadata:
 subjects:
 - name: storageos-cleanup-sa
   kind: ServiceAccount
-  namespace: {{ .Values.cluster.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   name: storageos-cleanup-cr
   kind: ClusterRole
@@ -104,7 +104,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "storageos-{{ .name }}-cleanup"
-  namespace: {{ $.Values.cluster.namespace }}
+  namespace: {{ .namespace }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": "hook-succeeded, before-hook-creation"
@@ -118,6 +118,8 @@ spec:
         image: bitnami/kubectl:1.14.1
         command:
           - kubectl
+          - -n
+          - {{ $.Values.cluster.namespace }}
           - delete
           {{- range .command }}
           - {{ . | quote }}

--- a/stable/storageos-operator/templates/rbac.yaml
+++ b/stable/storageos-operator/templates/rbac.yaml
@@ -22,6 +22,7 @@ rules:
   resources:
   - statefulsets
   - daemonsets
+  - deployments
   verbs:
   - "*"
 - apiGroups:
@@ -99,6 +100,19 @@ rules:
   verbs:
   - create
   - delete
+# OpenShift specific rule.
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - delete
+  - update
+  - get
+  - use
+  resourceNames:
+  - privileged
 
 ---
 

--- a/stable/storageos-operator/templates/storageoscluster_cr.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_cr.yaml
@@ -22,6 +22,7 @@ spec:
 
   csi:
     enable: {{ .Values.cluster.csi.enable }}
+    deploymentStrategy: {{ .Values.cluster.csi.deploymentStrategy }}
 
   {{- if .Values.cluster.sharedDir }}
   sharedDir: {{ .Values.cluster.sharedDir }}

--- a/stable/storageos-operator/templates/storageoscluster_crd.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_crd.yaml
@@ -41,6 +41,8 @@ spec:
               type: string
             namespace:
               type: string
+            k8sDistro:
+              type: string
             disableFencing:
               type: boolean
             disableTelemetry:
@@ -57,6 +59,8 @@ spec:
                   type: string
                 csiExternalAttacherContainer:
                   type: string
+                csiLivenessProbeContainer:
+                  type: string
             csi:
               properties:
                 enable:
@@ -67,6 +71,8 @@ spec:
                   type: boolean
                 enableNodePublishCreds:
                   type: boolean
+                deploymentStrategy:
+                  type: string
             service:
               properties:
                 name:

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ operator:
 
   image:
     repository: storageos/cluster-operator
-    tag: 1.1.0
+    tag: 1.2.0
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.
@@ -88,10 +88,11 @@ cluster:
     # [Docker Hub](https://hub.docker.com/r/storageos/node/).
     node:
       repository: storageos/node
-      tag: 1.2.0
+      tag: 1.2.1
 
   csi:
     enable: true
+    deploymentStrategy: deployment
 
 # The following is used for cleaning up unmanaged cluster resources when
 # auto-install is enabled.
@@ -104,6 +105,10 @@ cleanup:
     command:
       - "statefulset"
       - "storageos-statefulset"
+  - name: csi-helper
+    command:
+      - "deployment"
+      - "storageos-csi-helper"
   - name: serviceaccount
     command:
       - "serviceaccount"


### PR DESCRIPTION
Updates `storageos/storageos-operator` chart to be the same as `rancher/storageos-operator` chart.