### PR TITLE
Add etcd TLS secret to operator crd

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.1.0
+version: 0.1.1
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/templates/storageoscluster_cr.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_cr.yaml
@@ -31,6 +31,8 @@ spec:
   kvBackend:
     address: {{ .Values.cluster.kvBackend.address }}
     backend: {{ .Values.cluster.kvBackend.backend }}
+  tlsEtcdSecretRefName: {{ .Values.cluster.kvBackend.tlsSecretName }}
+  tlsEtcdSecretRefNamespace: {{ .Values.cluster.kvBackend.tlsSecretNamespace }}
   {{- end }}
 
   {{- if .Values.cluster.nodeSelectorTerm.key }}


### PR DESCRIPTION
The current storageos-cluster operator crd is missing the etcd TLS values if you want to use external etcd.