### PR TITLE
cleanup requires delete on deployments

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.2
+version: 0.2.3
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/templates/cleanup.yaml
+++ b/stable/storageos-operator/templates/cleanup.yaml
@@ -34,17 +34,18 @@ rules:
 # that it's in group "extensions". Not sure if it's a Job specific behavior,
 # because the daemonsets deployed by the operator use "apps" apiGroup.
 - apiGroups:
-  - "extensions"
+  - extensions
   resources:
-  - "daemonsets"
+  - daemonsets
   verbs:
-  - "delete"
+  - delete
 - apiGroups:
-  - "apps"
+  - apps
   resources:
-  - "statefulsets"
+  - statefulsets
+  - deployments
   verbs:
-  - "delete"
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
Fixes issue on cleanup by allowing deployments to be deleted by the cleanup user:

```
k -n storageos-operator logs storageos-csi-helper-cleanup-ssc8q 
Error from server (Forbidden): deployments.extensions "storageos-csi-helper" is forbidden: User "system:serviceaccount:storageos-operator:storageos-cleanup-sa" cannot delete resource "deployments" in API group "extensions" in the namespace "kube-system"
```