### PR TITLE
Hide etcd TLS if not enabled

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.4
+version: 0.2.5
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -109,20 +109,26 @@ questions:
     type: string
     label: External etcd address(es)
     show_if: "cluster.kvBackend.embedded=false"
+  - variable: cluster.kvBackend.tls
+    default: false
+    type: boolean
+    description: "Enable etcd TLS"
+    label: "TLS should be configured for external etcd to protect configuration data (Optional)."
+    show_if: "cluster.kvBackend.embedded=false"
   - variable: cluster.kvBackend.tlsSecretName
     required: false
     default: ""
     description: "Name of the secret that contains the etcd TLS certs. This secret is typically shared with etcd."
     type: string
     label: External etcd TLS secret name
-    show_if: "cluster.kvBackend.embedded=false"
+    show_if: "cluster.kvBackend.tls=true"
   - variable: cluster.kvBackend.tlsSecretNamespace
     required: false
     default: ""
     description: "Namespace of the secret that contains the etcd TLS certs. This secret is typically shared with etcd."
     type: string
     label: External etcd TLS secret namespace
-    show_if: "cluster.kvBackend.embedded=false"
+    show_if: "cluster.kvBackend.tls=true"
 
   # Node Selector Term.
   - variable: cluster.nodeSelectorTerm.key
@@ -133,7 +139,7 @@ questions:
     label: Node selector term key
   - variable: cluster.nodeSelectorTerm.value
     required: false
-    default: "true"
+    default: ""
     description: "Value of the node selector term match expression used to select the nodes to install StorageOS on."
     type: string
     label: Node selector term value


### PR DESCRIPTION
Cleans up the form a bit to only show etcd tls options if both external etcd enabled and etcd tls.

After this I'll PR against the Rancher chart repo.