### PR TITLE
Add a minimum helm version to README.md

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.5
+version: 0.2.6
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -23,6 +23,7 @@ configure a StorageOS cluster on kubernetes.
 
 ## Prerequisites
 
+- Helm 2.10+
 - Kubernetes 1.9+.
 - Privileged mode containers (enabled by default)
 - Kubernetes 1.9 only:


### PR DESCRIPTION
Looks like we need to install with at least helm 2.10 or we get an error `Error: apiVersion "storageos.com/v1" in storageos-operator/templates/storageoscluster_cr.yaml is not available`