### PR TITLE
Set tillerVersion for supported helm version

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.6
+version: 0.2.7
+tillerVersion: ">=2.10.0"
 keywords:
 - storage
 - block-storage


### PR DESCRIPTION
`tillerVersion` enforces the version of helm supported by the chart.

Refer: https://helm.sh/docs/chart_best_practices/#restricting-tiller-by-version

Improves https://github.com/storageos/charts/pull/66