### PR TITLE
Fix help text for multiple kv endpoints

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.9
+version: 0.2.10
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -162,7 +162,7 @@ Parameter | Description | Default
 `cluster.admin.password` | Password to authenticate to the StorageOS API with |
 `cluster.sharedDir` | The path shared into to kubelet container when running kubelet in a container |
 `cluster.kvBackend.embedded` | Use StorageOS embedded etcd | `true`
-`cluster.kvBackend.address` | External etcd address |
+`cluster.kvBackend.address` | List of etcd targets, in the form ip[:port], separated by commas |
 `cluster.kvBackend.backend` | Key-Value store backend name | `etcd`
 `cluster.kvBackend.tlsSecretName` | Name of the secret containing kv backend tls cert |
 `cluster.kvBackend.tlsSecretNamespace` | Namespace of the secret containing kv backend tls cert |

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -105,7 +105,7 @@ questions:
     label: "Use embedded KV store"
   - variable: cluster.kvBackend.address
     default: "10.0.0.1:2379"
-    description: "List of etcd targets, in the form ip[:port], separated by semi-colons.  Prefer multiple direct endpoints over a single load-balanced endpoint.  Only used if not using embedded KV store."
+    description: "List of etcd targets, in the form ip[:port], separated by commas.  Prefer multiple direct endpoints over a single load-balanced endpoint.  Only used if not using embedded KV store."
     type: string
     label: External etcd address(es)
     show_if: "cluster.kvBackend.embedded=false"


### PR DESCRIPTION
Help text said to separate with semi-colons, should have said commas.