### PR TITLE
Update rancher release for new dir structure

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
-# This script uses github hub https://hub.github.com/ to create a pull request.
+# This script uses github hub https://hub.github.com/ to create a pull request
+# and create a new rancher charts release.
 
 # Env vars definitions:-
 # 
 # GITHUB_USER: github username
 # GITHUB_EMAIL: github user email
 # GITHUB_TOKEN: github user API token with repo access permission only
+# SIGN_OFF_NAME: git commit sign-off name
 # VERSION: chart version
 # TARGET_REPO: upstream charts repo
 # UPSTREAM_REPO_PATH: upstream charts repo path
 # UPSTREAM_CHART_PATH: target charts dir path in the upstream charts repo
 # CHART_ROOT: path to the directory containing the chart.
+# CHART_NAME: name of the rancher chart
 
 
 # Setup netrc.
@@ -23,29 +26,63 @@ echo "machine github.com
 
 # Configure git.
 git config --global user.email "$GITHUB_EMAIL"
-git config --global user.name "$GITHUB_USER"
+git config --global user.name "$SIGN_OFF_NAME"
+
 
 # Clone rancher charts repo.
 git clone $TARGET_REPO $UPSTREAM_REPO_PATH
 
-# Copy storageos chart changes.
-cp -r $CHART_ROOT $UPSTREAM_REPO_PATH/$UPSTREAM_CHART_PATH
+# Get the latest release and new version.
+latest=$(ls $UPSTREAM_REPO_PATH/$UPSTREAM_CHART_PATH/$CHART_NAME | sort -nr | head -n1)
+new_version=v$VERSION
+
+# Compare latest rancher chart version with original chart version and exit if
+# the versions are the same.
+if [ "$latest" == "$new_version" ]; then
+    echo "No new rancher chart to publish"
+    exit 0
+else
+    echo "Preparing to publishing new chart version ${new_version}"
+fi
+
+echo "Using $latest to create base copy of $new_version"
+
+# Create a base copy by copying previous version to new version directory.
+latest_path=$UPSTREAM_REPO_PATH/$UPSTREAM_CHART_PATH/$CHART_NAME/$latest
+new_path=$UPSTREAM_REPO_PATH/$UPSTREAM_CHART_PATH/$CHART_NAME/$new_version
+cp -r $latest_path $new_path
+
+# Commit base copy.
+BASE_COPY_MSG="${CHART_NAME}: base copy ${latest} to ${new_version}"
+echo "Commit: ${BASE_COPY_MSG}"
+pushd $UPSTREAM_REPO_PATH
+git checkout -b $new_version
+git add *
+git status
+# Sign-off the commit.
+git commit -m "$BASE_COPY_MSG" -s
+git show --summary
+popd
+
+# Copy new chart changes.
+cp -r $CHART_ROOT/* $new_path
 
 # Create branch, commit and create a PR.
-MESSAGE="Update storageos-operator to version ${VERSION}"
-echo $MESSAGE
+MESSAGE="Update ${CHART_NAME} to version ${VERSION}"
+echo "Commit: ${MESSAGE}"
 pushd $UPSTREAM_REPO_PATH
 if ! git diff-index --quiet HEAD --; then
-    echo "Found changes in storageos-operator chart"
+    echo "Found changes in ${CHART_NAME} chart"
     echo "Creating pull request to the rancher chart.."
     git status
     hub remote add fork $FORK_REPO
     git checkout -b $VERSION
     git add *
     git status
-    git commit -m "$MESSAGE"
+    # Sign-off the commit.
+    git commit -m "$MESSAGE" -s
     git push fork $VERSION
     hub pull-request -m "$MESSAGE"
 else
-    echo "storageos-operator chart is in sync with rancher charts. Do nothing."
+    echo "${CHART_NAME} chart is in sync with rancher charts. Do nothing."
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,10 @@
 set -e
 
 # This script is used to publish storageos-operator chart to the upstream
-# rancher charts repo. It creates a diff of 
+# rancher charts repo. It creates a new base copy for the new version using
+# the latest release and copies the new changes to the new base copy. It then
+# creates a pull request with all the changes to the upstream rancher charts
+# repo.
 
 # Chart version.
 VERSION=$(yq r stable/storageos-operator/Chart.yaml version)
@@ -11,12 +14,14 @@ docker run --rm -ti \
     -v $PWD:/go/src/github.com/storageos/charts \
     -e GITHUB_USER=$GH_USER \
     -e GITHUB_EMAIL=$GH_EMAIL \
+    -e SIGN_OFF_NAME=$SIGN_OFF_NAME \
     -e GITHUB_TOKEN=$API_TOKEN \
     -e VERSION=$VERSION \
     -e TARGET_REPO="https://github.com/rancher/charts/" \
     -e FORK_REPO=$FORK_REPO \
     -e UPSTREAM_REPO_PATH="/go/src/github.com/rancher/charts" \
-    -e UPSTREAM_CHART_PATH="proposed/" \
-    -e CHART_ROOT=stable/storageos-operator/ \
+    -e UPSTREAM_CHART_PATH="proposed" \
+    -e CHART_NAME=$CHART_NAME \
+    -e CHART_ROOT=stable/storageos-operator \
     -w /go/src/github.com/storageos/charts \
     tianon/github-hub:2 bash -c "./scripts/create-pr.sh"


### PR DESCRIPTION
Rancher charts dir structure changed to have separate directory for each
releases. This change modifies the release script to create the
appropriate dir structure and also sign-off the commits.

The requirements include, creating a base for the new release using the
existing latest release and committing it separately, and then adding
the changes for new release on top of the copied base as another commit.