### PR TITLE
improve cleanup & fix tlsEtcdSecret config validation

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.10
+version: 0.2.11
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/templates/cleanup.yaml
+++ b/stable/storageos-operator/templates/cleanup.yaml
@@ -73,6 +73,7 @@ rules:
   - serviceaccounts
   - secrets
   - services
+  - configmaps
   verbs:
   - delete
 

--- a/stable/storageos-operator/templates/storageoscluster_cr.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_cr.yaml
@@ -32,7 +32,11 @@ spec:
   kvBackend:
     address: {{ .Values.cluster.kvBackend.address }}
     backend: {{ .Values.cluster.kvBackend.backend }}
+  {{- end }}
+  {{- if .Values.cluster.kvBackend.tlsSecretName }}
   tlsEtcdSecretRefName: {{ .Values.cluster.kvBackend.tlsSecretName }}
+  {{- end }}
+  {{- if .Values.cluster.kvBackend.tlsSecretNamespace }}
   tlsEtcdSecretRefNamespace: {{ .Values.cluster.kvBackend.tlsSecretNamespace }}
   {{- end }}
 

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -109,6 +109,15 @@ cleanup:
     command:
       - "deployment"
       - "storageos-csi-helper"
+  - name: scheduler
+    command:
+      - "deployment"
+      - "storageos-scheduler"
+  - name: configmap
+    command:
+      - "configmap"
+      - "storageos-scheduler-config"
+      - "storageos-scheduler-policy"
   - name: serviceaccount
     command:
       - "serviceaccount"
@@ -136,6 +145,8 @@ cleanup:
       - "storageos:driver-registrar"
       - "storageos:csi-attacher"
       - "storageos:csi-provisioner"
+      - "storageos:pod-fencer"
+      - "storageos:scheduler-extender"
   - name: clusterrolebinding
     command:
       - "clusterrolebinding"
@@ -143,6 +154,8 @@ cleanup:
       - "storageos:csi-attacher"
       - "storageos:driver-registrar"
       - "storageos:k8s-driver-registrar"
+      - "storageos:pod-fencer"
+      - "storageos:scheduler-extender"
   - name: storageclass
     command:
       - "storageclass"


### PR DESCRIPTION
Scheduler and pod-fencer resources are not cleaned up. This change adds
them in the cleanup resource list.

Also, adds conditionals around the tlsEtcdSecret configs to fix the validation errors (Rancher only):
```
validation failure list:
spec.tlsEtcdSecretRefNamespace in body must be of type string: "null"
spec.tlsEtcdSecretRefName in body must be of type string: "null"
```