### PR TITLE
create-pr: remove show summary statement

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -61,7 +61,6 @@ git add *
 git status
 # Sign-off the commit.
 git commit -m "$BASE_COPY_MSG" -s
-git show --summary
 popd
 
 # Copy new chart changes.


### PR DESCRIPTION
When git summary is big, it waits for keyboard input. Summary is not
needed.