### PR TITLE
Deprecate storageos chart

### DIFF
--- a/stable/storageos/Chart.yaml
+++ b/stable/storageos/Chart.yaml
@@ -1,5 +1,5 @@
 name: storageos
-version: 1.1.4
+version: 1.1.5
 description: Converged storage for containers
 appVersion: 1.3.0
 apiVersion: v1
@@ -11,8 +11,4 @@ home: https://storageos.com
 icon: https://storageos.com/wp-content/themes/storageOS/images/logo.svg
 sources:
 - https://github.com/storageos
-maintainers:
-- name: croomes
-  email: simon.croome@storageos.com
-- name: darkowlzz
-  email: sunny.gogoi@storageos.com
+deprecated: true


### PR DESCRIPTION
storageos-operator chart will be the main chart.

Ref: [Deprecating Charts](https://github.com/helm/helm/blob/master/docs/charts.md#deprecating-charts)