### PR TITLE
Deprecate storageoscluster-operator chart

### DIFF
--- a/stable/storageoscluster-operator/Chart.yaml
+++ b/stable/storageoscluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A StorageOS Cluster Operator chart for Kubernetes
 name: storageoscluster-operator
-version: 1.1.3
+version: 1.1.4
 keywords:
 - storage
 - block-storage
@@ -12,6 +12,4 @@ home: https://storageos.com
 icon: https://storageos.com/wp-content/themes/storageOS/images/logo.svg
 sources:
 - https://github.com/storageos
-maintainers:
-- name: darkowlzz
-  email: sunny.gogoi@storageos.com
+deprecated: true


### PR DESCRIPTION
storageos-operator will be the main chart.

Ref: [Deprecating Charts](https://github.com/helm/helm/blob/master/docs/charts.md#deprecating-charts)