### PR TITLE
Update to storageos-operator 1.4.0

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.3.0"
+appVersion: "1.4.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.11
+version: 0.2.12
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -150,7 +150,7 @@ Operator chart and their default values.
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
-`operator.image.tag` | StorageOS Operator container image tag | `1.3.0`
+`operator.image.tag` | StorageOS Operator container image tag | `1.4.0`
 `operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
 `podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
 `podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
@@ -172,7 +172,7 @@ Parameter | Description | Default
 `cluster.toleration.value` | Value of the pod toleration parameter |
 `cluster.disableTelemetry` | If true, no telemetry data will be collected from the cluster | `false`
 `cluster.images.node.repository` | StorageOS Node container image repository | `storageos/node`
-`cluster.images.node.tag` | StorageOS Node container image tag | `1.3.0`
+`cluster.images.node.tag` | StorageOS Node container image tag | `1.4.0`
 `cluster.csi.enable` | If true, CSI driver is enabled | `true`
 `cluster.csi.deploymentStrategy` | Whether CSI helpers should be deployed as a `deployment` or `statefulset` | `deployment`
 

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -32,7 +32,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "1.3.0"
+    default: "1.4.0"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -73,7 +73,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "1.3.0"
+    default: "1.4.0"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/stable/storageos-operator/templates/job_crd.yaml
+++ b/stable/storageos-operator/templates/job_crd.yaml
@@ -12,31 +12,74 @@ spec:
     plural: jobs
     singular: job
   scope: Namespaced
-  version: v1
   validation:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
-        metadata: {}
+        metadata:
+          type: object
         spec:
           properties:
-            image:
-              type: string
-            args: {}
-            mountPath:
+            args:
+              description: Args is an array of strings passed as an argument to the
+                job container.
+              items:
+                type: string
+              type: array
+            completionWord:
+              description: CompletionWord is the word that's looked for in the pod
+                logs to find out if a DaemonSet Pod has completed its task.
               type: string
             hostPath:
+              description: HostPath is the path in the host that's mounted into a
+                job container.
               type: string
-            completionWord:
+            image:
+              description: Image is the container image to run as the job.
               type: string
             labelSelector:
+              description: LabelSelector is the label selector for the job Pods.
               type: string
-            nodeSelectorTerms: {}
-            tolerations: {}
+            mountPath:
+              description: MountPath is the path in the job container where a volume
+                is mounted.
+              type: string
+            nodeSelectorTerms:
+              description: NodeSelectorTerms is the set of placement of the job pods
+                using node affinity requiredDuringSchedulingIgnoredDuringExecution.
+              items:
+                type: object
+              type: array
+            tolerations:
+              description: Tolerations is to set the placement of storageos pods using
+                pod toleration.
+              items:
+                type: object
+              type: array
+          required:
+          - image
+          - args
+          - mountPath
+          - hostPath
+          - completionWord
+          type: object
         status:
           properties:
             completed:
+              description: Completed indicates the complete status of job.
               type: boolean
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/stable/storageos-operator/templates/nfsserver_crd.yaml
+++ b/stable/storageos-operator/templates/nfsserver_crd.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nfsservers.storageos.com
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of the NFS server.
+    name: status
+    type: string
+  - JSONPath: .spec.resources.requests.storage
+    description: Capacity of the NFS server.
+    name: capacity
+    type: string
+  - JSONPath: .status.remoteTarget
+    description: Remote target address of the NFS server.
+    name: target
+    type: string
+  - JSONPath: .status.accessModes
+    description: Access modes supported by the NFS server.
+    name: access modes
+    type: string
+  - JSONPath: .spec.storageClassName
+    description: StorageClass used for creating the NFS volume.
+    name: storageclass
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: storageos.com
+  names:
+    kind: NFSServer
+    listKind: NFSServerList
+    plural: nfsservers
+    shortNames:
+    - nfsserver
+    singular: nfsserver
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: The annotations-related configuration to add/set on each
+                Pod related object.
+              type: object
+            export:
+              description: The parameters to configure the NFS export
+              properties:
+                name:
+                  description: Name of the export
+                  type: string
+                persistentVolumeClaim:
+                  description: PVC from which the NFS daemon gets storage for sharing
+                  type: object
+                server:
+                  description: The NFS server configuration
+                  properties:
+                    accessMode:
+                      description: Reading and Writing permissions on the export Valid
+                        values are "ReadOnly", "ReadWrite" and "none"
+                      type: string
+                    squash:
+                      description: This prevents the root users connected remotely
+                        from having root privileges Valid values are "none", "rootid",
+                        "root", and "all"
+                      type: string
+                  type: object
+              type: object
+            mountOptions:
+              description: PV mount options. Not validated - mount of the PVs will
+                simply fail if one is invalid.
+              items:
+                type: string
+              type: array
+            nfsContainer:
+              description: NFSContainer is the container image to use for the NFS
+                server.
+              type: string
+            persistentVolumeReclaimPolicy:
+              description: Reclamation policy for the persistent volume shared to
+                the user's pod.
+              type: string
+            resources:
+              description: Resources represents the minimum resources required
+              type: object
+            storageClassName:
+              description: StorageClassName is the name of the StorageClass used by
+                the NFS volume.
+              type: string
+            tolerations:
+              description: Tolerations is to set the placement of NFS server pods
+                using pod toleration.
+              items:
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            accessModes:
+              description: AccessModes is the access modes supported by the NFS server.
+              type: string
+            phase:
+              description: 'Phase is a simple, high-level summary of where the NFS
+                Server is in its lifecycle. Phase will be set to Ready when the NFS
+                Server is ready for use.  It is intended to be similar to the PodStatus
+                Phase described at: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podstatus-v1-core  There
+                are five possible phase values:   - Pending: The NFS Server has been
+                accepted by the Kubernetes system,     but one or more of the components
+                has not been created. This includes     time before being scheduled
+                as well as time spent downloading images     over the network, which
+                could take a while.   - Running: The NFS Server has been bound to
+                a node, and all of the     dependencies have been created.   - Succeeded:
+                All NFS Server dependencies have terminated in success,     and will
+                not be restarted.   - Failed: All NFS Server dependencies in the pod
+                have terminated, and     at least one container has terminated in
+                failure. The container     either exited with non-zero status or was
+                terminated by the system.   - Unknown: For some reason the state of
+                the NFS Server could not be     obtained, typically due to an error
+                in communicating with the host of     the pod.'
+              type: string
+            remoteTarget:
+              description: RemoteTarget is the connection string that clients can
+                use to access the shared filesystem.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/stable/storageos-operator/templates/rbac.yaml
+++ b/stable/storageos-operator/templates/rbac.yaml
@@ -15,6 +15,7 @@ rules:
   - storageosclusters
   - storageosupgrades
   - jobs
+  - nfsservers
   verbs:
   - "*"
 - apiGroups:
@@ -36,6 +37,7 @@ rules:
   - get
   - update
   - create
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -114,9 +116,10 @@ rules:
   verbs:
   - list
   - watch
-# OpenShift specific rule.
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -125,8 +128,6 @@ rules:
   - update
   - get
   - use
-  resourceNames:
-  - privileged
 
 ---
 

--- a/stable/storageos-operator/templates/storageoscluster_crd.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_crd.yaml
@@ -5,139 +5,299 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.ready
+    description: Ready status of the storageos nodes.
+    name: ready
+    type: string
+  - JSONPath: .status.phase
+    description: Status of the whole cluster.
+    name: status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: storageos.com
   names:
     kind: StorageOSCluster
     listKind: StorageOSClusterList
     plural: storageosclusters
-    singular: storageoscluster
     shortNames:
     - stos
+    singular: storageoscluster
   scope: Namespaced
-  version: v1
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    description: Ready status of the storageos nodes.
-    JSONPath: .status.ready
-  - name: Status
-    type: string
-    description: Status of the whole cluster.
-    JSONPath: .status.phase
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
-        metadata: {}
+        metadata:
+          type: object
         spec:
           properties:
-            join:
-              type: string
-            namespace:
-              type: string
-            k8sDistro:
-              type: string
-            disableFencing:
-              type: boolean
-            disableTelemetry:
-              type: boolean
-            disableTCMU:
-              type: boolean
-            forceTCMU:
-              type: boolean
-            disableScheduler:
-              type: boolean
-            images:
-              properties:
-                nodeContainer:
-                  type: string
-                initContainer:
-                  type: string
-                csiDriverRegistrarContainer:
-                  type: string
-                csiExternalProvisionerContainer:
-                  type: string
-                csiExternalAttacherContainer:
-                  type: string
-                csiLivenessProbeContainer:
-                  type: string
             csi:
+              description: CSI defines the configurations for CSI.
               properties:
+                deploymentStrategy:
+                  type: string
+                deviceDir:
+                  type: string
+                driverRegisterationMode:
+                  type: string
+                driverRequiresAttachment:
+                  type: string
                 enable:
-                  type: boolean
-                enableProvisionCreds:
                   type: boolean
                 enableControllerPublishCreds:
                   type: boolean
                 enableNodePublishCreds:
                   type: boolean
-                deploymentStrategy:
+                enableProvisionCreds:
+                  type: boolean
+                endpoint:
                   type: string
-            service:
+                kubeletDir:
+                  type: string
+                kubeletRegistrationPath:
+                  type: string
+                pluginDir:
+                  type: string
+                registrarSocketDir:
+                  type: string
+                registrationDir:
+                  type: string
+                version:
+                  type: string
+              type: object
+            debug:
+              description: Debug is to set debug mode of the cluster.
+              type: boolean
+            disableFencing:
+              description: 'Disable Pod Fencing.  With StatefulSets, Pods are only
+                re-scheduled if the Pod has been marked as killed.  In practice this
+                means that failover of a StatefulSet pod is a manual operation.  By
+                enabling Pod Fencing and setting the `storageos.com/fenced=true` label
+                on a Pod, StorageOS will enable automated Pod failover (by killing
+                the application Pod on the failed node) if the following conditions
+                exist:  - Pod fencing has not been explicitly disabled. - StorageOS
+                has determined that the node the Pod is running on is   offline.  StorageOS
+                uses Gossip and TCP checks and will retry for 30   seconds.  At this
+                point all volumes on the failed node are marked   offline (irrespective
+                of whether fencing is enabled) and volume   failover starts. - The
+                Pod has the label `storageos.com/fenced=true` set. - The Pod has at
+                least one StorageOS volume attached. - Each StorageOS volume has at
+                least 1 healthy replica.  When Pod Fencing is disabled, StorageOS
+                will not perform any interaction with Kubernetes when it detects that
+                a node has gone offline. Additionally, the Kubernetes permissions
+                required for Fencing will not be added to the StorageOS role.'
+              type: boolean
+            disableScheduler:
+              description: Disable StorageOS scheduler extender.
+              type: boolean
+            disableTCMU:
+              description: Disable TCMU can be set to true to disable the TCMU storage
+                driver.  This is required when there are multiple storage systems
+                running on the same node and you wish to avoid conflicts.  Only one
+                TCMU-based storage system can run on a node at a time.  Disabling
+                TCMU will degrade performance.
+              type: boolean
+            disableTelemetry:
+              description: Disable Telemetry.
+              type: boolean
+            forceTCMU:
+              description: Force TCMU can be set to true to ensure that TCMU is enabled
+                or cause StorageOS to abort startup.  At startup, StorageOS will automatically
+                fallback to non-TCMU mode if another TCMU-based storage system is
+                running on the node.  Since non-TCMU will degrade performance, this
+                may not always be desired.
+              type: boolean
+            images:
+              description: Images defines the various container images used in the
+                cluster.
               properties:
-                name:
+                csiClusterDriverRegistrarContainer:
                   type: string
-                type:
+                csiExternalAttacherContainer:
                   type: string
-                externalPort:
-                  type: integer
-                  format: int32
-                internalPort:
-                  type: integer
-                  format: int32
-            secretRefName:
-              type: string
-            secretRefNamespace:
-              type: string
-            tlsEtcdSecretRefName:
-              type: string
-            tlsEtcdSecretRefNamespace:
-              type: string
-            sharedDir:
-              type: string
+                csiExternalProvisionerContainer:
+                  type: string
+                csiLivenessProbeContainer:
+                  type: string
+                csiNodeDriverRegistrarContainer:
+                  type: string
+                hyperkubeContainer:
+                  type: string
+                initContainer:
+                  type: string
+                nodeContainer:
+                  type: string
+              type: object
             ingress:
+              description: Ingress defines the ingress configurations used in the
+                cluster.
               properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
                 enable:
                   type: boolean
                 hostname:
                   type: string
                 tls:
                   type: boolean
-                annotations: {}
+              type: object
+            join:
+              description: Join is the join token used for service discovery.
+              type: string
+            k8sDistro:
+              description: 'K8sDistro is the name of the Kubernetes distribution where
+                the operator is being deployed.  It should be in the format: `name[-1.0]`,
+                where the version is optional and should only be appended if known.  Suitable
+                names include: `openshift`, `rancher`, `aks`, `gke`, `eks`, or the
+                deployment method if using upstream directly, e.g `minishift` or `kubeadm`.  Setting
+                k8sDistro is optional, and will be used to simplify cluster configuration
+                by setting appropriate defaults for the distribution.  The distribution
+                information will also be included in the product telemetry (if enabled),
+                to help focus development efforts.'
+              type: string
             kvBackend:
+              description: KVBackend defines the key-value store backend used in the
+                cluster.
               properties:
                 address:
                   type: string
                 backend:
                   type: string
+              type: object
+            namespace:
+              description: Namespace is the kubernetes Namespace where storageos resources
+                are provisioned.
+              type: string
+            nodeSelectorTerms:
+              description: NodeSelectorTerms is to set the placement of storageos
+                pods using node affinity requiredDuringSchedulingIgnoredDuringExecution.
+              items:
+                type: object
+              type: array
             pause:
+              description: Pause is to pause the operator for the cluster.
               type: boolean
-            debug:
-              type: boolean
-            nodeSelectorTerms: {}
-            tolerations: {}
             resources:
+              description: Resources is to set the resource requirements of the storageos
+                containers.
+              type: object
+            secretRefName:
+              description: SecretRefName is the name of the secret object that contains
+                all the sensitive cluster configurations.
+              type: string
+            secretRefNamespace:
+              description: SecretRefNamespace is the namespace of the secret reference.
+              type: string
+            service:
+              description: Service is the Service configuration for the cluster nodes.
               properties:
-                limits: {}
-                requests: {}
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                externalPort:
+                  format: int64
+                  type: integer
+                internalPort:
+                  format: int64
+                  type: integer
+                name:
+                  type: string
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            sharedDir:
+              description: 'SharedDir is the shared directory to be used when the
+                kubelet is running in a container. Typically: "/var/lib/kubelet/plugins/kubernetes.io~storageos".
+                If not set, defaults will be used.'
+              type: string
+            storageClassName:
+              description: StorageClassName is the name of default StorageClass created
+                for StorageOS volumes.
+              type: string
+            tlsEtcdSecretRefName:
+              description: TLSEtcdSecretRefName is the name of the secret object that
+                contains the etcd TLS certs. This secret is shared with etcd, therefore
+                it's not part of the main storageos secret.
+              type: string
+            tlsEtcdSecretRefNamespace:
+              description: TLSEtcdSecretRefNamespace is the namespace of the etcd
+                TLS secret object.
+              type: string
+            tolerations:
+              description: Tolerations is to set the placement of storageos pods using
+                pod toleration.
+              items:
+                type: object
+              type: array
+          required:
+          - secretRefName
+          - secretRefNamespace
+          type: object
         status:
           properties:
-            phase:
-              type: string
-            nodeHealthStatus: {}
-            nodes:
-              type: array
-              items:
-                type: string
-            ready:
-              type: string
             members:
               properties:
-                ready: {}
-                unready: {}
+                ready:
+                  description: Ready are the storageos cluster members that are ready
+                    to serve requests. The member names are the same as the node IPs.
+                  items:
+                    type: string
+                  type: array
+                unready:
+                  description: Unready are the storageos cluster nodes not ready to
+                    serve requests.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            nodeHealthStatus:
+              additionalProperties:
+                properties:
+                  directfsInitiator:
+                    type: string
+                  director:
+                    type: string
+                  kv:
+                    type: string
+                  kvWrite:
+                    type: string
+                  nats:
+                    type: string
+                  presentation:
+                    type: string
+                  rdb:
+                    type: string
+                type: object
+              type: object
+            nodes:
+              items:
+                type: string
+              type: array
+            phase:
+              type: string
+            ready:
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/stable/storageos-operator/templates/storageosupgrade_crd.yaml
+++ b/stable/storageos-operator/templates/storageosupgrade_crd.yaml
@@ -12,20 +12,37 @@ spec:
     plural: storageosupgrades
     singular: storageosupgrade
   scope: Namespaced
-  version: v1
   validation:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
-        metadata: {}
+        metadata:
+          type: object
         spec:
           properties:
             newImage:
+              description: NewImage is the new StorageOS node container image.
               type: string
+          required:
+          - newImage
+          type: object
         status:
           properties:
             completed:
+              description: Completed is the status of upgrade process.
               type: boolean
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ operator:
 
   image:
     repository: storageos/cluster-operator
-    tag: 1.3.0
+    tag: 1.4.0
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.
@@ -88,7 +88,7 @@ cluster:
     # [Docker Hub](https://hub.docker.com/r/storageos/node/).
     node:
       repository: storageos/node
-      tag: 1.3.0
+      tag: 1.4.0
 
   csi:
     enable: true
@@ -147,6 +147,7 @@ cleanup:
       - "storageos:csi-provisioner"
       - "storageos:pod-fencer"
       - "storageos:scheduler-extender"
+      - "storageos:init"
   - name: clusterrolebinding
     command:
       - "clusterrolebinding"
@@ -156,6 +157,7 @@ cleanup:
       - "storageos:k8s-driver-registrar"
       - "storageos:pod-fencer"
       - "storageos:scheduler-extender"
+      - "storageos:init"
   - name: storageclass
     command:
       - "storageclass"


### PR DESCRIPTION
Adds the new NFSServer CRD and new permissions for the same.
Also, updates the existing CRDs with generated definitions from the
operator repo.