### PR TITLE
Update PSP API group to policy/v1beta1

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.12
+version: 0.2.13
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/templates/psp.yaml
+++ b/stable/storageos-operator/templates/psp.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.enabled }}
 
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "storageos.fullname" . }}-psp


### PR DESCRIPTION
API Group extensions/v1beta1 for PodSecurityPolicy is deprecated in
k8s 1.16. Use policy/v1beta1 API group. This was introduced in k8s
v1.10.

Rancher chart was already updated in https://github.com/rancher/charts/pull/237.

Refer: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16