### PR TITLE
create-pr: Set branch to create changes against

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,6 +18,7 @@ docker run --rm -ti \
     -e GITHUB_TOKEN=$API_TOKEN \
     -e VERSION=$VERSION \
     -e TARGET_REPO="https://github.com/rancher/charts/" \
+    -e TARGET_BRANCH="partners" \
     -e FORK_REPO=$FORK_REPO \
     -e UPSTREAM_REPO_PATH="/go/src/github.com/rancher/charts" \
     -e UPSTREAM_CHART_PATH="proposed" \


### PR DESCRIPTION
[Rancher charts](https://github.com/rancher/charts) changed their default branch from `dev` to `master` and all the partners should submit their charts to the `partners` branch.

This change updates the create-pr.sh script to set upstream repo branch
against which the changes should be created for rancher charts.

Improvement: avoid creating second branch from an existing new branch.

Updated the [rancher fork's](https://github.com/darkowlzz/charts-2/) default branch to `master`. 