### PR TITLE
Update KinD, k8s image & charts-testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: required
 env:
   global:
     - CHANGE_MINIKUBE_NONE_USER=true
-    - K8S_VERSION="v1.14.2"
+    - K8S_VERSION="v1.16.3"
     # - MINIKUBE_VERSION="v0.28.2"
     - CHART_TESTING_IMAGE="quay.io/helmpack/chart-testing"
-    - CHART_TESTING_TAG="v2.3.3"
+    - CHART_TESTING_TAG="v2.4.0"
     - CHARTS_REPO="https://github.com/storageos/charts"
 
 before_install:

--- a/stable/storageoscluster-operator/Chart.yaml
+++ b/stable/storageoscluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A StorageOS Cluster Operator chart for Kubernetes
 name: storageoscluster-operator
-version: 1.1.4
+version: 1.1.5
 keywords:
 - storage
 - block-storage

--- a/stable/storageoscluster-operator/templates/psp.yaml
+++ b/stable/storageoscluster-operator/templates/psp.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.enabled }}
 
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "storageoscluster-operator.fullname" . }}-psp


### PR DESCRIPTION
Update KinD to 0.6.0 and KinD node image to use k8s 1.16.3.
Also update charts-testing framework to v2.4.0.