### PR TITLE
Update chart for cluster-operator 1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 env:
   global:
     - CHANGE_MINIKUBE_NONE_USER=true
-    - K8S_VERSION="v1.16.3"
+    - K8S_VERSION="v1.17.0"
     - KUBEVAL_VERSION="0.14.0"
     - HELM_VERSION="v2.16.1"
     - CHART_TESTING_IMAGE="quay.io/helmpack/chart-testing"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,7 +18,7 @@ docker run --rm -ti \
     -e GITHUB_TOKEN=$API_TOKEN \
     -e VERSION=$VERSION \
     -e TARGET_REPO="https://github.com/rancher/charts/" \
-    -e TARGET_BRANCH="partners" \
+    -e TARGET_BRANCH="master" \
     -e FORK_REPO=$FORK_REPO \
     -e UPSTREAM_REPO_PATH="/go/src/github.com/rancher/charts" \
     -e UPSTREAM_CHART_PATH="proposed" \

--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.5.1"
+appVersion: "1.5.2"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.16
+version: 0.2.17
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -150,7 +150,7 @@ Operator chart and their default values.
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
-`operator.image.tag` | StorageOS Operator container image tag | `1.5.1`
+`operator.image.tag` | StorageOS Operator container image tag | `1.5.2`
 `operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
 `podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
 `podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
@@ -172,7 +172,7 @@ Parameter | Description | Default
 `cluster.toleration.value` | Value of the pod toleration parameter |
 `cluster.disableTelemetry` | If true, no telemetry data will be collected from the cluster | `false`
 `cluster.images.node.repository` | StorageOS Node container image repository | `storageos/node`
-`cluster.images.node.tag` | StorageOS Node container image tag | `1.5.1`
+`cluster.images.node.tag` | StorageOS Node container image tag | `1.5.2`
 `cluster.csi.enable` | If true, CSI driver is enabled | `true`
 `cluster.csi.deploymentStrategy` | Whether CSI helpers should be deployed as a `deployment` or `statefulset` | `deployment`
 

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -32,7 +32,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "1.5.1"
+    default: "1.5.2"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -73,7 +73,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "1.5.1"
+    default: "1.5.2"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/stable/storageos-operator/templates/rbac.yaml
+++ b/stable/storageos-operator/templates/rbac.yaml
@@ -94,6 +94,7 @@ rules:
   - volumeattachments
   - csinodeinfos
   - csinodes
+  - csidrivers
   verbs:
   - create
   - delete
@@ -101,6 +102,7 @@ rules:
   - list
   - get
   - update
+  - patch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -160,6 +162,14 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
 
 ---
 

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ operator:
 
   image:
     repository: storageos/cluster-operator
-    tag: 1.5.1
+    tag: 1.5.2
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.
@@ -88,7 +88,7 @@ cluster:
     # [Docker Hub](https://hub.docker.com/r/storageos/node/).
     node:
       repository: storageos/node
-      tag: 1.5.1
+      tag: 1.5.2
 
   csi:
     enable: true

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -117,7 +117,7 @@ get_changed_charts() {
 
 # Render helm chart templates and validate the manifests.
 validate_manifests() {
-    kubeval_flags="--strict --skip-kinds CustomResourceDefinition"
+    kubeval_flags="--strict --ignore-missing-schemas --skip-kinds CustomResourceDefinition"
     local changed_charts=("")
     while IFS='' read -r line; do changed_charts+=("$line"); done < <(get_changed_charts)
     echo "------------------------------------------------------------------------------------------------------------------------"

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -21,7 +21,7 @@ enable_lio() {
 run_kind() {
     echo "Download kind binary..."
     # docker run --rm -it -v "$(pwd)":/go/bin golang go get sigs.k8s.io/kind && sudo mv kind /usr/local/bin/
-    wget -O kind 'https://github.com/kubernetes-sigs/kind/releases/download/v0.6.0/kind-linux-amd64' --no-check-certificate && chmod +x kind && sudo mv kind /usr/local/bin/
+    wget -O kind 'https://github.com/kubernetes-sigs/kind/releases/download/v0.6.1/kind-linux-amd64' --no-check-certificate && chmod +x kind && sudo mv kind /usr/local/bin/
 
     echo "Download kubectl..."
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${K8S_VERSION}"/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/


### PR DESCRIPTION
Also changes the rancher charts target branch to `master` because `partners` branch lacks the latest updates.