### PR TITLE
Update node container to 1.5.3 and permissions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 StorageOS
+Copyright (c) 2020 StorageOS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.3"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.18
+version: 0.2.19
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/LICENSE
+++ b/stable/storageos-operator/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 StorageOS
+Copyright (c) 2020 StorageOS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -171,8 +171,8 @@ Parameter | Description | Default
 `cluster.toleration.key` | Key of the pod toleration parameter |
 `cluster.toleration.value` | Value of the pod toleration parameter |
 `cluster.disableTelemetry` | If true, no telemetry data will be collected from the cluster | `false`
-`cluster.images.node.repository` | StorageOS Node container image repository | `storageos/node`
-`cluster.images.node.tag` | StorageOS Node container image tag | `1.5.2`
+`cluster.images.node.repository` | StorageOS Node container image repository |
+`cluster.images.node.tag` | StorageOS Node container image tag |
 `cluster.images.init.repository` | StorageOS init container image repository |
 `cluster.images.init.tag` | StorageOS init container image tag |
 `cluster.images.csiV1ClusterDriverRegistrar.repository` | CSI v1 Cluster Driver Registrar image repository |

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -73,7 +73,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "1.5.2"
+    default: "1.5.3"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/stable/storageos-operator/templates/cleanup.yaml
+++ b/stable/storageos-operator/templates/cleanup.yaml
@@ -44,6 +44,8 @@ rules:
   - apps
   resources:
   - statefulsets
+  - deployments
+  - daemonsets
   verbs:
   - delete
 - apiGroups:

--- a/stable/storageos-operator/templates/cleanup.yaml
+++ b/stable/storageos-operator/templates/cleanup.yaml
@@ -78,6 +78,14 @@ rules:
   - configmaps
   verbs:
   - delete
+- apiGroups:
+  - storageos.com
+  resources:
+  - storageosclusters
+  verbs:
+  - get
+  - patch
+  - delete
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -99,10 +107,42 @@ roleRef:
 
 ---
 
+# Delete the StorageOSCluster object by removing the finalizer.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "storageos-storageoscluster-cleanup"
+  namespace: {{ .namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, before-hook-creation"
+    "helm.sh/hook-weight": "3"
+spec:
+  template:
+    spec:
+      serviceAccountName: storageos-cleanup
+      containers:
+      - name: "storageos-storageoscluster-cleanup"
+        image: "{{ $.Values.cleanup.images.kubectl.repository }}:{{ $.Values.cleanup.images.kubectl.tag }}"
+        command:
+          - kubectl
+          - -n
+          - {{ $.Release.namespace }}
+          - patch
+          - stos
+          - {{ $.Values.cluster.name }}
+          - --type=merge
+          - --patch={"metadata":{"finalizers":null}}
+      restartPolicy: Never
+  backoffLimit: 4
+
+---
+
 # Iterate through the Values.cleanup list and create jobs to delete all the
 # unmanaged resources of the cluster.
 
-{{- range .Values.cleanup }}
+{{- range .Values.cleanup.resources }}
 
 apiVersion: batch/v1
 kind: Job
@@ -119,7 +159,7 @@ spec:
       serviceAccountName: storageos-cleanup
       containers:
       - name: "storageos-{{ .name }}-cleanup"
-        image: bitnami/kubectl:1.14.1
+        image: "{{ $.Values.cleanup.images.kubectl.repository }}:{{ $.Values.cleanup.images.kubectl.tag }}"
         command:
           - kubectl
           - -n

--- a/stable/storageos-operator/templates/operator.yaml
+++ b/stable/storageos-operator/templates/operator.yaml
@@ -35,32 +35,58 @@ spec:
           command:
           - cluster-operator
           env:
+            {{- if and .Values.cluster.images.node.repository .Values.cluster.images.node.tag }}
             - name: RELATED_IMAGE_STORAGEOS_NODE
               value: "{{ .Values.cluster.images.node.repository }}:{{ .Values.cluster.images.node.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.init.repository .Values.cluster.images.init.tag }}
             - name: RELATED_IMAGE_STORAGEOS_INIT
               value: "{{ .Values.cluster.images.init.repository }}:{{ .Values.cluster.images.init.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ClusterDriverRegistrar.repository .Values.cluster.images.csiV1ClusterDriverRegistrar.tag }}
             - name: RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR
               value: "{{ .Values.cluster.images.csiV1ClusterDriverRegistrar.repository }}:{{ .Values.cluster.images.csiV1ClusterDriverRegistrar.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1NodeDriverRegistrar.repository .Values.cluster.images.csiV1NodeDriverRegistrar.tag }}
             - name: RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR
               value: "{{ .Values.cluster.images.csiV1NodeDriverRegistrar.repository }}:{{ .Values.cluster.images.csiV1NodeDriverRegistrar.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalProvisioner.repository .Values.cluster.images.csiV1ExternalProvisioner.tag }}
             - name: RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER
               value: "{{ .Values.cluster.images.csiV1ExternalProvisioner.repository }}:{{ .Values.cluster.images.csiV1ExternalProvisioner.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalAttacher.repository .Values.cluster.images.csiV1ExternalAttacher.tag }}
             - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
               value: "{{ .Values.cluster.images.csiV1ExternalAttacher.repository }}:{{ .Values.cluster.images.csiV1ExternalAttacher.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalAttacherV2.repository .Values.cluster.images.csiV1ExternalAttacherV2.tag }}
             - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
               value: "{{ .Values.cluster.images.csiV1ExternalAttacherV2.repository }}:{{ .Values.cluster.images.csiV1ExternalAttacherV2.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1LivenessProbe.repository .Values.cluster.images.csiV1LivenessProbe.tag }}
             - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
               value: "{{ .Values.cluster.images.csiV1LivenessProbe.repository }}:{{ .Values.cluster.images.csiV1LivenessProbe.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV0DriverRegistrar.repository .Values.cluster.images.csiV0DriverRegistrar.tag }}
             - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
               value: "{{ .Values.cluster.images.csiV0DriverRegistrar.repository }}:{{ .Values.cluster.images.csiV0DriverRegistrar.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV0ExternalProvisioner.repository .Values.cluster.images.csiV0ExternalProvisioner.tag }}
             - name: RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER
               value: "{{ .Values.cluster.images.csiV0ExternalProvisioner.repository }}:{{ .Values.cluster.images.csiV0ExternalProvisioner.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV0ExternalAttacher.repository .Values.cluster.images.csiV0ExternalAttacher.tag }}
             - name: RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER
               value: "{{ .Values.cluster.images.csiV0ExternalAttacher.repository }}:{{ .Values.cluster.images.csiV0ExternalAttacher.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.nfs.repository .Values.cluster.images.nfs.tag }}
             - name: RELATED_IMAGE_NFS
               value: "{{ .Values.cluster.images.nfs.repository }}:{{ .Values.cluster.images.nfs.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.kubeScheduler.repository .Values.cluster.images.kubeScheduler.tag }}
             - name: RELATED_IMAGE_KUBE_SCHEDULER
               value: "{{ .Values.cluster.images.kubeScheduler.repository }}:{{ .Values.cluster.images.kubeScheduler.tag }}"
+            {{- end }}
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -87,8 +87,8 @@ cluster:
     # nodeContainer is the StorageOS node image to use, available from the
     # [Docker Hub](https://hub.docker.com/r/storageos/node/).
     node:
-      repository: storageos/node
-      tag: 1.5.2
+      repository:
+      tag:
     init:
       repository:
       tag:

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -133,70 +133,75 @@ cluster:
 # The following is used for cleaning up unmanaged cluster resources when
 # auto-install is enabled.
 cleanup:
-  - name: daemonset
-    command:
-      - "daemonset"
-      - "storageos-daemonset"
-  - name: statefulset
-    command:
-      - "statefulset"
-      - "storageos-statefulset"
-  - name: csi-helper
-    command:
-      - "deployment"
-      - "storageos-csi-helper"
-  - name: scheduler
-    command:
-      - "deployment"
-      - "storageos-scheduler"
-  - name: configmap
-    command:
-      - "configmap"
-      - "storageos-scheduler-config"
-      - "storageos-scheduler-policy"
-  - name: serviceaccount
-    command:
-      - "serviceaccount"
-      - "storageos-daemonset-sa"
-      - "storageos-statefulset-sa"
-  - name: role
-    command:
-      - "role"
-      - "storageos:key-management"
-  - name: rolebinding
-    command:
-      - "rolebinding"
-      - "storageos:key-management"
-  - name: secret
-    command:
-      - "secret"
-      - "init-secret"
-  - name: service
-    command:
-      - "service"
-      - "storageos"
-  - name: clusterrole
-    command:
-      - "clusterrole"
-      - "storageos:driver-registrar"
-      - "storageos:csi-attacher"
-      - "storageos:csi-provisioner"
-      - "storageos:pod-fencer"
-      - "storageos:scheduler-extender"
-      - "storageos:init"
-      - "storageos:nfs-provisioner"
-  - name: clusterrolebinding
-    command:
-      - "clusterrolebinding"
-      - "storageos:csi-provisioner"
-      - "storageos:csi-attacher"
-      - "storageos:driver-registrar"
-      - "storageos:k8s-driver-registrar"
-      - "storageos:pod-fencer"
-      - "storageos:scheduler-extender"
-      - "storageos:init"
-      - "storageos:nfs-provisioner"
-  - name: storageclass
-    command:
-      - "storageclass"
-      - "fast"
+  images:
+    kubectl:
+      repository: bitnami/kubectl
+      tag: 1.14.1
+  resources:
+    - name: daemonset
+      command:
+        - "daemonset"
+        - "storageos-daemonset"
+    - name: statefulset
+      command:
+        - "statefulset"
+        - "storageos-statefulset"
+    - name: csi-helper
+      command:
+        - "deployment"
+        - "storageos-csi-helper"
+    - name: scheduler
+      command:
+        - "deployment"
+        - "storageos-scheduler"
+    - name: configmap
+      command:
+        - "configmap"
+        - "storageos-scheduler-config"
+        - "storageos-scheduler-policy"
+    - name: serviceaccount
+      command:
+        - "serviceaccount"
+        - "storageos-daemonset-sa"
+        - "storageos-statefulset-sa"
+    - name: role
+      command:
+        - "role"
+        - "storageos:key-management"
+    - name: rolebinding
+      command:
+        - "rolebinding"
+        - "storageos:key-management"
+    - name: secret
+      command:
+        - "secret"
+        - "init-secret"
+    - name: service
+      command:
+        - "service"
+        - "storageos"
+    - name: clusterrole
+      command:
+        - "clusterrole"
+        - "storageos:driver-registrar"
+        - "storageos:csi-attacher"
+        - "storageos:csi-provisioner"
+        - "storageos:pod-fencer"
+        - "storageos:scheduler-extender"
+        - "storageos:init"
+        - "storageos:nfs-provisioner"
+    - name: clusterrolebinding
+      command:
+        - "clusterrolebinding"
+        - "storageos:csi-provisioner"
+        - "storageos:csi-attacher"
+        - "storageos:driver-registrar"
+        - "storageos:k8s-driver-registrar"
+        - "storageos:pod-fencer"
+        - "storageos:scheduler-extender"
+        - "storageos:init"
+        - "storageos:nfs-provisioner"
+    - name: storageclass
+      command:
+        - "storageclass"
+        - "fast"


### PR DESCRIPTION
- Updates node container to 1.5.3, use implicit image from operator
by default.
- Updates year in license
- Updates the cleanup permissions to add deployments, because the CSI
helpers can also be deployed as deployments.
- StorageOSCluster object should also be cleaned up when cleaning up a
cluster with auto-install. This is done by patching the custom resource
and removing the finalizer.
- Add conditionals around related images env vars. Conditionals help ensure that the env vars are not set when the image repo and tag are missing.

