### PR TITLE
Helm3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ jobs:
         provider: script
         script: bash scripts/release.sh
         on:
-          branch: master
+          branch: helm2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - K8S_VERSION="v1.17.0"
     - KUBEVAL_VERSION="0.14.0"
-    - HELM_VERSION="v3.0.3"
+    - HELM_VERSION="v3.2.1"
     - CHART_TESTING_IMAGE="quay.io/helmpack/chart-testing"
-    - CHART_TESTING_TAG="v3.0.0-beta.1"
+    - CHART_TESTING_TAG="v3.0.0-rc.1"
     - CHARTS_REPO="https://github.com/storageos/charts"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - K8S_VERSION="v1.17.0"
     - KUBEVAL_VERSION="0.14.0"
-    - HELM_VERSION="v2.16.1"
+    - HELM_VERSION="v3.0.3"
     - CHART_TESTING_IMAGE="quay.io/helmpack/chart-testing"
-    - CHART_TESTING_TAG="v2.4.0"
+    - CHART_TESTING_TAG="v3.0.0-beta.1"
     - CHARTS_REPO="https://github.com/storageos/charts"
 
 before_install:

--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,9 +1,8 @@
-apiVersion: v1
-appVersion: "v2.1.0"
+apiVersion: v2
+appVersion: "1.5.3"
 description: Cloud Native storage for containers
 name: storageos-operator
 version: 0.3.0
-tillerVersion: ">=2.10.0"
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "v2.0.0"
+appVersion: "v2.1.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.3.0
+version: 0.4.0
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.5.3"
+appVersion: "v2.0.0"
 description: Cloud Native storage for containers
 name: storageos-operator
 version: 0.3.0

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -149,7 +149,7 @@ Learn more about advanced configuration options
 To check cluster status, run:
 
 ```console
-$ kubectl get storageoscluster
+$ kubectl get storageoscluster --namespace storageos-operator
 NAME                READY     STATUS    AGE
 example-storageos   3/3       Running   4m
 ```

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -19,14 +19,10 @@ configure a StorageOS cluster on kubernetes.
 
 ## Prerequisites
 
-- Helm 2.10+
-- Kubernetes 1.9+.
+- Helm 3
+- Kubernetes 1.13+
 - Privileged mode containers (enabled by default)
 - Etcd cluster
-- Kubernetes 1.9 only:
-  - Feature gate: MountPropagation=true.  This can be done by appending
-    `--feature-gates MountPropagation=true` to the kube-apiserver and kubelet
-    services.
 
 Refer to the [StorageOS prerequisites
 docs](https://docs.storageos.com/docs/prerequisites/) for more information.
@@ -37,13 +33,14 @@ docs](https://docs.storageos.com/docs/prerequisites/) for more information.
 # Add storageos charts repo.
 $ helm repo add storageos https://charts.storageos.com
 # Install the chart in a namespace.
-$ helm install storageos/storageos-operator \
+$ kubectl create namespace storageos-operator
+$ helm install my-storageos storageos/storageos-operator \
     --namespace storageos-operator \
     --set cluster.kvBackend.address=<etcd-node-ip>:2379 \
     --set cluster.admin.password=<password>
 ```
 
-This will install the StorageOSCluster operator in `storageos-operator`
+This will install the StorageOS cluster operator in `storageos-operator`
 namespace and deploys StorageOS with a minimal configuration. Etcd address
 (kvBackend) and admin password are mandatory values to install the chart. To
 avoid passing the password as a flag, create a values.yaml file and pass the
@@ -70,7 +67,28 @@ $ helm install storageos/storageos-operator \
     --values <values-file>
 ```
 
-> **Tip**: List all releases using `helm list`
+```yaml
+cluster:
+  kvBackend:
+    address: <etcd-node-ip>:2379
+  admin:
+    password: <password>
+```
+
+The password must be at least 8 characters long and the default username is
+`storageos`, which can be changed like the above values. Find more information
+about installing etcd in our [etcd
+docs](https://docs.storageos.com/docs/prerequisites/etcd/).
+
+Install the chart with the values file:
+
+```console
+$ helm install my-storageos storageos/storageos-operator \
+    --namespace storageos-operator \
+    --values <values-file>
+```
+
+> **Tip**: List all releases using `helm list -A`
 
 ## Creating a StorageOS cluster manually
 
@@ -228,7 +246,7 @@ storageos cluster and all the associated resources.
 In the above example,
 
 ```console
-kubectl delete storageoscluster example-storageos
+$ kubectl delete storageoscluster example-storageos
 ```
 
 would delete the custom resource and the cluster.
@@ -238,8 +256,11 @@ would delete the custom resource and the cluster.
 To uninstall/delete the storageos cluster operator deployment:
 
 ```console
-helm delete --purge <release-name>
+$ helm uninstall <release-name> --namespace storageos-operator
 ```
+
+If the chart was installed with cluster auto-provisioning enabled, chart
+uninstall will clean-up the installed StorageOS cluster resources as well.
 
 Learn more about configuring the StorageOS Operator on
 [GitHub](https://github.com/storageos/cluster-operator).

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -1,8 +1,8 @@
 # StorageOS Operator Helm Chart
 
-> **Note**: This chart defaults to StorageOS v2. To upgrade from a previous
-> chart or from StorageOS version 1.x to 2.x, please contact support for
-> assistance.
+> **Note**: This chart requires Helm 3 and defaults to StorageOS v2. To upgrade
+> from a previous chart or from StorageOS version 1.x to 2.x, please contact
+> support for assistance.
 
 [StorageOS](https://storageos.com) is a software-based storage platform
 designed for cloud-native applications. By deploying StorageOS on your

--- a/stable/storageos-operator/crds/job_crd.yaml
+++ b/stable/storageos-operator/crds/job_crd.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: jobs.storageos.com
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: storageos.com
   names:

--- a/stable/storageos-operator/crds/nfsserver_crd.yaml
+++ b/stable/storageos-operator/crds/nfsserver_crd.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: nfsservers.storageos.com
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.phase

--- a/stable/storageos-operator/crds/storageoscluster_crd.yaml
+++ b/stable/storageos-operator/crds/storageoscluster_crd.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: storageosclusters.storageos.com
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.ready

--- a/stable/storageos-operator/crds/storageosupgrade_crd.yaml
+++ b/stable/storageos-operator/crds/storageosupgrade_crd.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: storageosupgrades.storageos.com
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: storageos.com
   names:

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -2,6 +2,8 @@ categories:
 - storage
 labels:
   io.rancher.certified: partner
+  io.cattle.role: cluster
+rancher_min_version: 2.4.0
 questions:
 - variable: k8sDistro
   default: rancher

--- a/stable/storageos-operator/templates/NOTES.txt
+++ b/stable/storageos-operator/templates/NOTES.txt
@@ -55,3 +55,4 @@ Newly installed StorageOS clusters require a license to function. For
 instructions on applying our free developer license, or obtaining a commercial
 license, please see our documentation at
 https://docs.storageos.com/docs/reference/licence/.
+

--- a/stable/storageos-operator/templates/operator.yaml
+++ b/stable/storageos-operator/templates/operator.yaml
@@ -67,6 +67,10 @@ spec:
             - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
               value: "{{ .Values.cluster.images.csiV1LivenessProbe.repository }}:{{ .Values.cluster.images.csiV1LivenessProbe.tag }}"
             {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalResizer.repository .Values.cluster.images.csiV1ExternalResizer.tag }}
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER
+              value: "{{ .Values.cluster.images.csiV1ExternalResizer.repository }}:{{ .Values.cluster.images.csiV1ExternalResizer.tag }}"
+            {{- end }}
             {{- if and .Values.cluster.images.csiV0DriverRegistrar.repository .Values.cluster.images.csiV0DriverRegistrar.tag }}
             - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
               value: "{{ .Values.cluster.images.csiV0DriverRegistrar.repository }}:{{ .Values.cluster.images.csiV0DriverRegistrar.tag }}"

--- a/stable/storageos-operator/templates/secrets.yaml
+++ b/stable/storageos-operator/templates/secrets.yaml
@@ -17,7 +17,8 @@ data:
   # Add base64 encoded TLS cert and key below if ingress.tls is set to true.
   # tls.crt:
   # tls.key:
-  # Add base64 encoded creds below for CSI credentials.
+  # Add base64 encoded creds below for CSI credentials. The credentials are
+  # validated above. Use them here directly.
   csiProvisionUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
   csiProvisionPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
   csiControllerPublishUsername: {{ .Values.cluster.admin.username | b64enc | quote }}

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -12,7 +12,8 @@ serviceAccount:
 
 podSecurityPolicy:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     ## Specify pod annotations
     ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
     ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -24,7 +25,6 @@ podSecurityPolicy:
 
 # operator-specific configuation parameters.
 operator:
-
   image:
     repository: storageos/cluster-operator
     tag: v2.1.0
@@ -46,7 +46,6 @@ cluster:
 
   # Default admin account.
   admin:
-
     # Username to authenticate to the StorageOS API with.
     username: storageos
 
@@ -130,7 +129,6 @@ cluster:
       tag:
 
   csi:
-    enable: true
     deploymentStrategy: deployment
 
 # The following is used for cleaning up unmanaged cluster resources when

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -4,4 +4,4 @@ chart-dirs:
   - stable
 # excluded-charts:
 #   - common
-helm-extra-args: --timeout 160
+helm-extra-args: --timeout 160s

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -204,9 +204,6 @@ main() {
     docker_exec kubectl cluster-info
     echo
 
-    # Install_tiller
-    install_tiller
-
     echo "Ready for testing"
 
     docker_exec ct install --config /workdir/test/ct.yaml


### PR DESCRIPTION
- Update chart apiVerion to v2.
- Move CRDs to crds/ dir at the root of the chart.
- Remove crd-install hook annotation from the CRDs.
- Fix the typo in the cleanup manifest for namespace variable.
- Update charts-testing framework to v3.
- Remove tiller installation from e2e test.