### PR TITLE
Update chart to cluster-operator v2.1.0

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.5.3"
+appVersion: "v2.1.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.2.19
+version: 0.3.0
 tillerVersion: ">=2.10.0"
 keywords:
 - storage
@@ -10,7 +10,7 @@ keywords:
 - volume
 - operator
 home: https://storageos.com
-icon: https://storageos.com/wp-content/themes/storageOS/images/logo.svg
+icon: https://docs.storageos.com/images/logo-helm.svg
 sources:
 - https://github.com/storageos
 maintainers:

--- a/stable/storageos-operator/app-readme.md
+++ b/stable/storageos-operator/app-readme.md
@@ -3,7 +3,7 @@
 [StorageOS](https://storageos.com) is a cloud native, software-defined storage
 platform that transforms commodity server or cloud based disk capacity into
 enterprise-class persistent storage for containers. StorageOS is ideal for
-deploying databases, message busses, and other mission-critical stateful
+deploying databases, message queues, and other mission-critical stateful
 solutions, where rapid recovery and fault tolerance are essential.
 
 The StorageOS Operator installs and manages StorageOS within a cluster.
@@ -11,10 +11,22 @@ Cluster nodes may contribute local or attached disk-based storage into a
 distributed pool, which is then available to all cluster members via a
 global namespace.
 
+StorageOS requires an etcd cluster in order to function. Find out more about
+setting up an etcd cluster in our [etcd
+docs](https://docs.storageos.com/docs/prerequisites/etcd/).
+
 By default, a minimal configuration of StorageOS is installed. To set advanced
 configurations, disable the default installation of StorageOS and create a
 custom StorageOSCluster resource
 ([documentation](https://docs.storageos.com/docs/reference/cluster-operator/examples)).
 
-`Notes: The StorageOS Operator must be installed in the System Project with
-Cluster Role`
+Newly installed StorageOS clusters require a license to function. For
+instructions on applying our free developer license, or obtaining a commercial
+license, please see our documentation at
+https://docs.storageos.com/docs/reference/licence/.
+
+> **Notes**:
+> - The StorageOS Operator must be installed in the System Project with Cluster
+> Role.
+> - To upgrade from StorageOS version 1.x to 2.x, please contact support
+> for assistance.

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -5,11 +5,12 @@ labels:
 questions:
 - variable: k8sDistro
   default: rancher
-  description: "k8sDistro is used to fine-tune configuration for specific
-  Kubernetes distributions. It is also included in anonymized telemetry data so
-  that we can focus development effort most effectively.
+  description: "Kubernetes Distribution is used to fine-tune configuration for
+  specific Kubernetes distributions. It is also included in anonymized
+  telemetry data so that we can focus development effort most effectively.
   Example values: rancher, openshift"
   type: string
+  label: Kubernetes Distribution
 
 # Operator image configuration.
 - variable: defaultImage

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -5,8 +5,11 @@ labels:
 questions:
 - variable: k8sDistro
   default: rancher
-  description: "Kubernetes Distribution"
-  show_if: false
+  description: "k8sDistro is used to fine-tune configuration for specific
+  Kubernetes distributions. It is also included in anonymized telemetry data so
+  that we can focus development effort most effectively.
+  Example values: rancher, openshift"
+  type: string
 
 # Operator image configuration.
 - variable: defaultImage
@@ -32,7 +35,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "1.5.3"
+    default: "v2.1.0"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -46,13 +49,6 @@ questions:
   show_subquestion_if: true
   group: "StorageOS Cluster"
   subquestions:
-
-  # CSI configuration.
-  - variable: cluster.csi.enable
-    default: true
-    description: "Use Container Storage Interface (CSI) driver"
-    label: Use CSI Driver
-    type: boolean
 
   # Cluster metadata.
   - variable: cluster.name
@@ -73,10 +69,17 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "1.5.3"
+    default: "v2.1.0"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag
+
+  # Telemetry.
+  - variable: cluster.disableTelemetry
+    default: false
+    type: boolean
+    description: "Disable telemetry data collection.  See https://docs.storageos.com/docs/reference/telemetry for more information."
+    label: Disable Telemetry
 
   # Credentials.
   - variable: cluster.admin.username
@@ -86,29 +89,21 @@ questions:
     label: Username
   - variable: cluster.admin.password
     default: ""
-    description: "Password of the StorageOS administrator account.  If empty, a random password will be generated."
+    description: "Password of the StorageOS administrator account. Must be at
+    least 8 characters long"
     type: password
     label: Password
 
-  # Telemetry.
-  - variable: cluster.disableTelemetry
-    default: false
-    type: boolean
-    description: "Disable telemetry data collection.  See https://docs.storageos.com/docs/reference/telemetry for more information."
-    label: Disable Telemetry
-
   # KV store backend.
-  - variable: cluster.kvBackend.embedded
-    default: true
-    type: boolean
-    description: "Use embedded KV store for testing.  Select false to use external etcd for production deployments."
-    label: "Use embedded KV store"
   - variable: cluster.kvBackend.address
-    default: "10.0.0.1:2379"
-    description: "List of etcd targets, in the form ip[:port], separated by commas.  Prefer multiple direct endpoints over a single load-balanced endpoint.  Only used if not using embedded KV store."
+    required: true
+    default: ""
+    description: "List of etcd targets, in the form ip[:port], separated by
+    commas. Prefer multiple direct endpoints over a single load-balanced
+    endpoint. See https://docs.storageos.com/docs/prerequisites/etcd/ for more
+    information."
     type: string
     label: External etcd address(es)
-    show_if: "cluster.kvBackend.embedded=false"
   - variable: cluster.kvBackend.tls
     default: false
     type: boolean

--- a/stable/storageos-operator/templates/NOTES.txt
+++ b/stable/storageos-operator/templates/NOTES.txt
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: storageos-api
-  namespace: default
+  namespace: storageos-operator
   labels:
     app: storageos
 type: kubernetes.io/storageos
@@ -20,6 +20,14 @@ data:
   # echo -n '<secret>' | base64
   apiUsername: c3RvcmFnZW9z
   apiPassword: c3RvcmFnZW9z
+  csiProvisionUsername: c3RvcmFnZW9z
+  csiProvisionPassword: c3RvcmFnZW9z
+  csiControllerPublishUsername: c3RvcmFnZW9z
+  csiControllerPublishPassword: c3RvcmFnZW9z
+  csiNodePublishUsername: c3RvcmFnZW9z
+  csiNodePublishPassword: c3RvcmFnZW9z
+  csiControllerExpandUsername: c3RvcmFnZW9z
+  csiControllerExpandPassword: c3RvcmFnZW9z
 
 2. Create a StorageOS custom resource that references the secret created
 above (storageos-api in the above example). When the resource is created, the
@@ -29,9 +37,21 @@ apiVersion: storageos.com/v1
 kind: StorageOSCluster
 metadata:
   name: example-storageos
-  namespace: default
+  namespace: storageos-operator
 spec:
   secretRefName: storageos-api
-  secretRefNamespace: default
+  secretRefNamespace: storageos-operator
   csi:
     enable: true
+    deploymentStrategy: "deployment"
+    enableProvisionCreds: true
+    enableControllerPublishCreds: true
+    enableNodePublishCreds: true
+    enableControllerExpandCreds: true
+  kvBackend:
+    address: <etcd-endpoint>
+
+Newly installed StorageOS clusters require a license to function. For
+instructions on applying our free developer license, or obtaining a commercial
+license, please see our documentation at
+https://docs.storageos.com/docs/reference/licence/.

--- a/stable/storageos-operator/templates/_helpers.tpl
+++ b/stable/storageos-operator/templates/_helpers.tpl
@@ -41,3 +41,27 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate the admin username to be of minimum length
+*/}}
+{{- define "validate-username" -}}
+{{ $length := len .Values.cluster.admin.username }}
+{{- if ge $length 3 -}}
+{{ .Values.cluster.admin.username }}
+{{- else -}}
+{{- fail "Invalid username. Must be at least 3 characters." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate the admin password to be of minimum length
+*/}}
+{{- define "validate-password" -}}
+{{ $length := len .Values.cluster.admin.password }}
+{{- if ge $length 8 -}}
+{{ .Values.cluster.admin.password }}
+{{- else -}}
+{{- fail "Invalid password. Must be at least 8 characters." -}}
+{{- end -}}
+{{- end -}}

--- a/stable/storageos-operator/templates/cleanup.yaml
+++ b/stable/storageos-operator/templates/cleanup.yaml
@@ -128,7 +128,7 @@ spec:
         command:
           - kubectl
           - -n
-          - {{ $.Release.namespace }}
+          - {{ $.Release.Namespace }}
           - patch
           - stos
           - {{ $.Values.cluster.name }}

--- a/stable/storageos-operator/templates/operator.yaml
+++ b/stable/storageos-operator/templates/operator.yaml
@@ -87,6 +87,10 @@ spec:
             - name: RELATED_IMAGE_KUBE_SCHEDULER
               value: "{{ .Values.cluster.images.kubeScheduler.repository }}:{{ .Values.cluster.images.kubeScheduler.tag }}"
             {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalResizer.repository .Values.cluster.images.csiV1ExternalResizer.tag }}
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER
+              value: "{{ .Values.cluster.images.csiV1ExternalResizer.repository }}:{{ .Values.cluster.images.csiV1ExternalResizer.tag }}"
+            {{- end }}
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/stable/storageos-operator/templates/rbac.yaml
+++ b/stable/storageos-operator/templates/rbac.yaml
@@ -64,10 +64,12 @@ rules:
   - services
   - services/finalizers
   - persistentvolumeclaims
+  - persistentvolumeclaims/status
   - persistentvolumes
   - configmaps
   - replicationcontrollers
   - pods/binding
+  - pods/status
   - endpoints
   verbs:
   - create
@@ -162,6 +164,7 @@ rules:
   - events
   verbs:
   - create
+  - patch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/stable/storageos-operator/templates/secrets.yaml
+++ b/stable/storageos-operator/templates/secrets.yaml
@@ -12,21 +12,19 @@ metadata:
     release: {{ .Release.Name }}
 type: "kubernetes.io/storageos"
 data:
-  apiUsername: {{ default "" .Values.cluster.admin.username | b64enc | quote }}
-  {{ if .Values.cluster.admin.password }}
-  apiPassword: {{ default "" .Values.cluster.admin.password | b64enc | quote }}
-  {{ else }}
-  apiPassword: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  apiUsername: {{ include "validate-username" . | b64enc | quote }}
+  apiPassword: {{ include "validate-password" . | b64enc | quote }}
   # Add base64 encoded TLS cert and key below if ingress.tls is set to true.
   # tls.crt:
   # tls.key:
   # Add base64 encoded creds below for CSI credentials.
-  # csiProvisionUsername:
-  # csiProvisionPassword:
-  # csiControllerPublishUsername:
-  # csiControllerPublishPassword:
-  # csiNodePublishUsername:
-  # csiNodePublishPassword:
+  csiProvisionUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiProvisionPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
+  csiControllerPublishUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiControllerPublishPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
+  csiNodePublishUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiNodePublishPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
+  csiControllerExpandUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiControllerExpandPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
 
 {{- end }}

--- a/stable/storageos-operator/templates/storageoscluster_cr.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_cr.yaml
@@ -16,18 +16,20 @@ spec:
   {{- end }}
 
   csi:
-    enable: {{ .Values.cluster.csi.enable }}
+    enable: true
     deploymentStrategy: {{ .Values.cluster.csi.deploymentStrategy }}
+    enableProvisionCreds: true
+    enableControllerPublishCreds: true
+    enableNodePublishCreds: true
+    enableControllerExpandCreds: true
 
   {{- if .Values.cluster.sharedDir }}
   sharedDir: {{ .Values.cluster.sharedDir }}
   {{- end }}
 
-  {{- if eq .Values.cluster.kvBackend.embedded false }}
   kvBackend:
-    address: {{ .Values.cluster.kvBackend.address }}
+    address: {{ required "kv backend address must be set" .Values.cluster.kvBackend.address }}
     backend: {{ .Values.cluster.kvBackend.backend }}
-  {{- end }}
   {{- if .Values.cluster.kvBackend.tlsSecretName }}
   tlsEtcdSecretRefName: {{ .Values.cluster.kvBackend.tlsSecretName }}
   {{- end }}

--- a/stable/storageos-operator/templates/storageoscluster_crd.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_crd.yaml
@@ -58,6 +58,8 @@ spec:
                   type: string
                 enable:
                   type: boolean
+                enableControllerExpandCreds:
+                  type: boolean
                 enableControllerPublishCreds:
                   type: boolean
                 enableNodePublishCreds:
@@ -130,6 +132,8 @@ spec:
                 csiExternalAttacherContainer:
                   type: string
                 csiExternalProvisionerContainer:
+                  type: string
+                csiExternalResizerContainer:
                   type: string
                 csiLivenessProbeContainer:
                   type: string

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ operator:
 
   image:
     repository: storageos/cluster-operator
-    tag: 1.5.3
+    tag: v2.1.0
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.
@@ -50,8 +50,8 @@ cluster:
     # Username to authenticate to the StorageOS API with.
     username: storageos
 
-    # Password to authenticate to the StorageOS API with. If empty, a random
-    # password will be generated and set in the secretRefName secret.
+    # Password to authenticate to the StorageOS API with. This must be at least
+    # 8 characters long.
     password:
 
   # sharedDir should be set if running kubelet in a container.  This should
@@ -62,7 +62,7 @@ cluster:
 
   # Key-Value store backend.
   kvBackend:
-    embedded: true
+    embedded: false
     address:
     backend: etcd
     tlsSecretName:
@@ -110,6 +110,9 @@ cluster:
     csiV1LivenessProbe:
       repository:
       tag:
+    csiV1ExternalResizer:
+      repository:
+      tag:
     csiV0DriverRegistrar:
       repository:
       tag:
@@ -136,7 +139,7 @@ cleanup:
   images:
     kubectl:
       repository: bitnami/kubectl
-      tag: 1.14.1
+      tag: 1.18.2
   resources:
     - name: daemonset
       command:

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -167,6 +167,8 @@ cleanup:
         - "serviceaccount"
         - "storageos-daemonset-sa"
         - "storageos-statefulset-sa"
+        - "storageos-csi-helper-sa"
+        - "storageos-scheduler-sa"
     - name: role
       command:
         - "role"
@@ -193,6 +195,7 @@ cleanup:
         - "storageos:scheduler-extender"
         - "storageos:init"
         - "storageos:nfs-provisioner"
+        - "storageos:csi-resizer"
     - name: clusterrolebinding
       command:
         - "clusterrolebinding"
@@ -204,6 +207,7 @@ cleanup:
         - "storageos:scheduler-extender"
         - "storageos:init"
         - "storageos:nfs-provisioner"
+        - "storageos:csi-resizer"
     - name: storageclass
       command:
         - "storageclass"

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -131,7 +131,13 @@ validate_manifests() {
         rm -rf stable
         mkdir stable
         # Render chart with default values and validate.
-        helm template "${REPO_ROOT}/${chart_name}" --output-dir stable > /dev/null 2>&1
+        helm_template_vals=""
+        if [ "$chart_name" = "stable/storageos-operator" ]; then
+            # NOTE: With StorageOS v2, the KV backend became mandatory and admin
+            # password must be at least 8 characters.
+            helm_template_vals="--set cluster.kvBackend.address=foo:2379 --set cluster.admin.password=storageos"
+        fi
+        helm template "${REPO_ROOT}/${chart_name}" $helm_template_vals --output-dir stable > /dev/null 2>&1
         TEMPLATE_FILES="${chart_name}/templates"
         if [ -d "${TEMPLATE_FILES}" ]
         then


### PR DESCRIPTION
- Defaults to StorageOS v2 install.
- Chart version: 0.3.0.
- Remove password generation because it's error prone. Regenerates upon update.
- CSI Resizer enabled by default.