### PR TITLE
Fix chart icon URI protocol to file

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
 - volume
 - operator
 home: https://storageos.com
-icon: https://../storageos.svg
+icon: file://../storageos.svg
 sources:
 - https://github.com/storageos
 maintainers:


### PR DESCRIPTION
NOTE: Not updating the chart version to avoid publishing a new version. This change is a fix from the upstream review of the proposed changes.