### PR TITLE
rancher/questions: Set password as required

### DIFF
--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -89,6 +89,7 @@ questions:
     type: string
     label: Username
   - variable: cluster.admin.password
+    required: true
     default: ""
     description: "Password of the StorageOS administrator account. Must be at
     least 8 characters long"


### PR DESCRIPTION
NOTE: Not updating the chart version to avoid publishing a new version. This change is based on the upstream review of the proposed changes.