### PR TITLE
helm2: Update to StorageOS v2.3.0

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v2.2.0"
+appVersion: "v2.3.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.3.1
+version: 0.3.2
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -164,13 +164,6 @@ metadata:
 spec:
   secretRefName: "storageos-api"
   secretRefNamespace: "storageos-operator"
-  csi:
-    enable: true
-    deploymentStrategy: "deployment"
-    enableProvisionCreds: true
-    enableControllerPublishCreds: true
-    enableNodePublishCreds: true
-    enableControllerExpandCreds: true
   kvBackend:
     address: "etcd-client.etcd.svc.cluster.local:2379"
     # address: '10.42.15.23:2379,10.42.12.22:2379,10.42.13.16:2379' # You can set ETCD server IPs.
@@ -241,6 +234,8 @@ Parameter | Description | Default
 `cluster.disableTelemetry` | If true, no telemetry data will be collected from the cluster | `false`
 `cluster.images.node.repository` | StorageOS Node container image repository |
 `cluster.images.node.tag` | StorageOS Node container image tag |
+`cluster.images.apiManager.repository` | StorageOS API Manager container image repository |
+`cluster.images.apiManager.tag` | StorageOS API Manager container image tag |
 `cluster.images.init.repository` | StorageOS init container image repository |
 `cluster.images.init.tag` | StorageOS init container image tag |
 `cluster.images.csiV1ClusterDriverRegistrar.repository` | CSI v1 Cluster Driver Registrar image repository |

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -36,7 +36,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "v2.2.0"
+    default: "v2.3.0"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -70,7 +70,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "v2.2.0"
+    default: "v2.3.0"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag
@@ -111,7 +111,6 @@ questions:
     type: boolean
     description: "Enable etcd TLS"
     label: "TLS should be configured for external etcd to protect configuration data (Optional)."
-    show_if: "cluster.kvBackend.embedded=false"
   - variable: cluster.kvBackend.tlsSecretName
     required: false
     default: ""

--- a/stable/storageos-operator/templates/operator.yaml
+++ b/stable/storageos-operator/templates/operator.yaml
@@ -39,6 +39,10 @@ spec:
             - name: RELATED_IMAGE_STORAGEOS_NODE
               value: "{{ .Values.cluster.images.node.repository }}:{{ .Values.cluster.images.node.tag }}"
             {{- end }}
+            {{- if and .Values.cluster.images.apiManager.repository .Values.cluster.images.apiManager.tag }}
+            - name: RELATED_IMAGE_API_MANAGER
+              value: "{{ .Values.cluster.images.apiManager.repository }}:{{ .Values.cluster.images.apiManager.tag }}"
+            {{- end }}
             {{- if and .Values.cluster.images.init.repository .Values.cluster.images.init.tag }}
             - name: RELATED_IMAGE_STORAGEOS_INIT
               value: "{{ .Values.cluster.images.init.repository }}:{{ .Values.cluster.images.init.tag }}"

--- a/stable/storageos-operator/templates/rbac.yaml
+++ b/stable/storageos-operator/templates/rbac.yaml
@@ -67,6 +67,7 @@ rules:
   - persistentvolumeclaims/status
   - persistentvolumes
   - configmaps
+  - configmaps/status
   - replicationcontrollers
   - pods/binding
   - pods/status

--- a/stable/storageos-operator/templates/storageoscluster_crd.yaml
+++ b/stable/storageos-operator/templates/storageoscluster_crd.yaml
@@ -129,6 +129,8 @@ spec:
               description: Images defines the various container images used in the
                 cluster.
               properties:
+                apiManagerContainer:
+                  type: string
                 csiClusterDriverRegistrarContainer:
                   type: string
                 csiExternalAttacherContainer:

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ operator:
 
   image:
     repository: storageos/cluster-operator
-    tag: v2.2.0
+    tag: v2.3.0
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.
@@ -87,6 +87,9 @@ cluster:
     # nodeContainer is the StorageOS node image to use, available from the
     # [Docker Hub](https://hub.docker.com/r/storageos/node/).
     node:
+      repository:
+      tag:
+    apiManager:
       repository:
       tag:
     init:
@@ -157,6 +160,10 @@ cleanup:
       command:
         - "deployment"
         - "storageos-scheduler"
+    - name: api-manager
+      command:
+        - "deployment"
+        - "storageos-api-manager"
     - name: configmap
       command:
         - "configmap"
@@ -169,6 +176,7 @@ cleanup:
         - "storageos-statefulset-sa"
         - "storageos-csi-helper-sa"
         - "storageos-scheduler-sa"
+        - "storageos-api-manager-sa"
     - name: role
       command:
         - "role"
@@ -185,6 +193,10 @@ cleanup:
       command:
         - "service"
         - "storageos"
+    - name: api-manager-service
+      command:
+        - "service"
+        - "storageos-api-manager-metrics"
     - name: clusterrole
       command:
         - "clusterrole"
@@ -194,6 +206,7 @@ cleanup:
         - "storageos:pod-fencer"
         - "storageos:scheduler-extender"
         - "storageos:init"
+        - "storageos:api-manager"
         - "storageos:nfs-provisioner"
         - "storageos:csi-resizer"
     - name: clusterrolebinding
@@ -206,6 +219,7 @@ cleanup:
         - "storageos:pod-fencer"
         - "storageos:scheduler-extender"
         - "storageos:init"
+        - "storageos:api-manager"
         - "storageos:nfs-provisioner"
         - "storageos:csi-resizer"
     - name: storageclass


### PR DESCRIPTION
- Update container images.
- Update CRD and RBAC.
- Add cleanup for api-manager deployment resources.
- Fix rancher charts unable to set etcd secrets.