### PR TITLE
helm2: Change the rancher charts target path

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ docker run --rm -ti \
     -e TARGET_BRANCH="master" \
     -e FORK_REPO=$FORK_REPO \
     -e UPSTREAM_REPO_PATH="/go/src/github.com/rancher/charts" \
-    -e UPSTREAM_CHART_PATH="proposed" \
+    -e UPSTREAM_CHART_PATH="charts" \
     -e CHART_NAME=$CHART_NAME \
     -e CHART_ROOT=stable/storageos-operator \
     -w /go/src/github.com/storageos/charts \


### PR DESCRIPTION
Rancher charts should be moved into charts/ dir in the upstream rancher
charts repo. This changes `UPSTREAM_CHART_PATH` parameter of the
create-pr.sh script to the new path, `charts`.

Refer: https://github.com/rancher/charts/pull/811#pullrequestreview-531605137
