### PR TITLE
v2.3.3 helm2 updates

### DIFF
--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v2.3.1"
+appVersion: "v2.3.3"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.3.2
+version: 0.3.3
 tillerVersion: ">=2.10.0"
 keywords:
 - storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -216,7 +216,7 @@ Operator chart and their default values.
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
-`operator.image.tag` | StorageOS Operator container image tag | `v2.3.1`
+`operator.image.tag` | StorageOS Operator container image tag | `v2.3.3`
 `operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
 `podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
 `podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -36,7 +36,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "v2.3.1"
+    default: "v2.3.3"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -70,7 +70,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "v2.3.1"
+    default: "v2.3.3"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ operator:
 
   image:
     repository: storageos/cluster-operator
-    tag: v2.3.1
+    tag: v2.3.3
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -4,4 +4,6 @@ chart-dirs:
   - stable
 # excluded-charts:
 #   - common
-helm-extra-args: --timeout 160
+helm-extra-args: --timeout 160s
+chart-repos:
+  - stable=https://charts.helm.sh/stable

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -54,7 +54,7 @@ install_tiller() {
     # Install Tiller with RBAC
     kubectl -n kube-system create sa tiller
     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-    docker_exec helm init --service-account tiller
+    docker_exec helm init --service-account tiller --config /workdir/test/ct.yaml
     echo "Wait for Tiller to be up and ready..."
     until kubectl -n kube-system get pods 2>&1 | grep -w "tiller-deploy"  | grep -w "1/1"; do sleep 1; done
     echo
@@ -111,7 +111,7 @@ install_kubeval() {
 # Get a list of charts that changed.
 get_changed_charts() {
     local changed_charts=("")
-    while IFS='' read -r line; do changed_charts+=("$line"); done < <(docker run --rm -v "$(pwd):/workdir" --workdir /workdir "${CHART_TESTING_IMAGE}:${CHART_TESTING_TAG}" ct list-changed --chart-dirs stable )
+    while IFS='' read -r line; do changed_charts+=("$line"); done < <(docker run --rm -v "$(pwd):/workdir" --workdir /workdir "${CHART_TESTING_IMAGE}:${CHART_TESTING_TAG}" ct list-changed --config /workdir/test/ct.yaml --chart-dirs stable )
     echo "${changed_charts[*]}"
 }
 


### PR DESCRIPTION
Bumps helm2/Rancher chart to v2.3.3.

Moves the stable charts repo so that https://github.com/helm/chart-testing CI tools pass.

The CircleCI job will fail on this branch but should pass once the change to the config file has merged.  I didn't want to test on the PR branch as it will trigger a release.