### PR TITLE
Bump ct image to use new stable helm repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v3.0.0
+      - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
       - run:
@@ -14,7 +14,7 @@ jobs:
 
   deploy:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v2.0.5
+      - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
       - run: test/repo-sync.sh


### PR DESCRIPTION
Fixes:

```
Error: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```