### PR TITLE
helm3: Update to StorageOS v2.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v3.0.0
+      - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - KUBEVAL_VERSION="0.15.0"
     - HELM_VERSION="v3.2.1"
     - CHART_TESTING_IMAGE="quay.io/helmpack/chart-testing"
-    - CHART_TESTING_TAG="v3.0.0"
+    - CHART_TESTING_TAG="v3.3.1"
     - CHARTS_REPO="https://github.com/storageos/charts"
 
 before_install:

--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "v2.3.3"
+appVersion: "v2.4.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.4.5
+version: 0.4.6
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/Chart.yaml
+++ b/stable/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "v2.3.1"
+appVersion: "v2.3.3"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.4.4
+version: 0.4.5
 keywords:
 - storage
 - block-storage

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -35,10 +35,13 @@ additional capacity, features and support plans contact sales@storageos.com.
     changed blocks.
 * Multiple AccessModes - dynamically provision ReadWriteOnce or ReadWriteMany
     volumes.
+* Rapid Failover - quickly detects node failure and automates recovery actions
+    without administrator intervention.
+* Data Encryption - both in transit and at rest.
 * Scalability - disaggregated consensus means no single scheduling point of
     failure.
-* Thin provisioning - Only consume the space you need in a storage pool.
-* Data reduction - Transparent inline data compression to reduce the amount of
+* Thin provisioning - only consume the space you need in a storage pool.
+* Data reduction - transparent inline data compression to reduce the amount of
     storage used in a backing store as well as reducing the network bandwidth
     requirements for replication.
 * Flexible configuration - all features can be enabled per volume, using PVC
@@ -46,7 +49,7 @@ additional capacity, features and support plans contact sales@storageos.com.
 * Multi-tenancy - fully supports standard Namespace and RBAC methods.
 * Observability & instrumentation - Log streams for observability and
     Prometheus support for instrumentation.
-* Deployment flexibility - Scale up or scale out storage based on application
+* Deployment flexibility - scale up or scale out storage based on application
     requirements. Works with any infrastructure – on-premises, VM, bare metal
     or cloud.
 
@@ -234,7 +237,7 @@ Operator chart and their default values.
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
-`operator.image.tag` | StorageOS Operator container image tag | `v2.3.3`
+`operator.image.tag` | StorageOS Operator container image tag | `v2.4.0`
 `operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
 `podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
 `podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`

--- a/stable/storageos-operator/README.md
+++ b/stable/storageos-operator/README.md
@@ -234,7 +234,7 @@ Operator chart and their default values.
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
-`operator.image.tag` | StorageOS Operator container image tag | `v2.3.1`
+`operator.image.tag` | StorageOS Operator container image tag | `v2.3.3`
 `operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
 `podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
 `podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`

--- a/stable/storageos-operator/app-readme.md
+++ b/stable/storageos-operator/app-readme.md
@@ -31,10 +31,13 @@ additional capacity, features and support plans contact sales@storageos.com.
     changed blocks.
 * Multiple AccessModes - dynamically provision ReadWriteOnce or ReadWriteMany
     volumes.
+* Rapid Failover - quickly detects node failure and automates recovery actions
+    without administrator intervention.
+* Data Encryption - both in transit and at rest.
 * Scalability - disaggregated consensus means no single scheduling point of
     failure.
-* Thin provisioning - Only consume the space you need in a storage pool.
-* Data reduction - Transparent inline data compression to reduce the amount of
+* Thin provisioning - only consume the space you need in a storage pool.
+* Data reduction - transparent inline data compression to reduce the amount of
     storage used in a backing store as well as reducing the network bandwidth
     requirements for replication.
 * Flexible configuration - all features can be enabled per volume, using PVC
@@ -42,7 +45,7 @@ additional capacity, features and support plans contact sales@storageos.com.
 * Multi-tenancy - fully supports standard Namespace and RBAC methods.
 * Observability & instrumentation - Log streams for observability and
     Prometheus support for instrumentation.
-* Deployment flexibility - Scale up or scale out storage based on application
+* Deployment flexibility - scale up or scale out storage based on application
     requirements. Works with any infrastructure – on-premises, VM, bare metal
     or cloud.
 

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -38,7 +38,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "v2.3.1"
+    default: "v2.3.3"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -72,7 +72,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "v2.3.1"
+    default: "v2.3.3"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -101,7 +101,7 @@ questions:
   - variable: cluster.kvBackend.address
     required: true
     default: ""
-    description: "List of etcd targets, in the form ip[:port], separated by
+    description: "List of etcd targets, in the form ip:port, separated by
     commas. Prefer multiple direct endpoints over a single load-balanced
     endpoint. See https://docs.storageos.com/docs/prerequisites/etcd/ for more
     information."

--- a/stable/storageos-operator/questions.yml
+++ b/stable/storageos-operator/questions.yml
@@ -38,7 +38,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "v2.3.3"
+    default: "v2.4.0"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -72,7 +72,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "v2.3.3"
+    default: "v2.4.0"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/stable/storageos-operator/templates/rbac.yaml
+++ b/stable/storageos-operator/templates/rbac.yaml
@@ -62,6 +62,7 @@ rules:
   - serviceaccounts
   - secrets
   - services
+  - services/status
   - services/finalizers
   - persistentvolumeclaims
   - persistentvolumeclaims/status
@@ -72,6 +73,7 @@ rules:
   - pods/binding
   - pods/status
   - endpoints
+  - endpoints/status
   verbs:
   - create
   - patch
@@ -95,6 +97,7 @@ rules:
   resources:
   - storageclasses
   - volumeattachments
+  - volumeattachments/status
   - csinodeinfos
   - csinodes
   - csidrivers

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ podSecurityPolicy:
 operator:
   image:
     repository: storageos/cluster-operator
-    tag: v2.3.1
+    tag: v2.3.3
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ podSecurityPolicy:
 operator:
   image:
     repository: storageos/cluster-operator
-    tag: v2.3.3
+    tag: v2.4.0
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.

--- a/stable/storageos-operator/values.yaml
+++ b/stable/storageos-operator/values.yaml
@@ -167,6 +167,8 @@ cleanup:
         - "configmap"
         - "storageos-scheduler-config"
         - "storageos-scheduler-policy"
+        - "storageos-api-manager-lease"
+        - "storageos-node-config"
     - name: serviceaccount
       command:
         - "serviceaccount"
@@ -175,14 +177,6 @@ cleanup:
         - "storageos-csi-helper-sa"
         - "storageos-scheduler-sa"
         - "storageos-api-manager-sa"
-    - name: role
-      command:
-        - "role"
-        - "storageos:key-management"
-    - name: rolebinding
-      command:
-        - "rolebinding"
-        - "storageos:key-management"
     - name: secret
       command:
         - "secret"
@@ -195,6 +189,7 @@ cleanup:
       command:
         - "service"
         - "storageos-api-manager-metrics"
+        - "storageos-webhook"
     - name: clusterrole
       command:
         - "clusterrole"
@@ -207,6 +202,7 @@ cleanup:
         - "storageos:api-manager"
         - "storageos:nfs-provisioner"
         - "storageos:csi-resizer"
+        - "storageos:key-management"
     - name: clusterrolebinding
       command:
         - "clusterrolebinding"
@@ -220,6 +216,7 @@ cleanup:
         - "storageos:api-manager"
         - "storageos:nfs-provisioner"
         - "storageos:csi-resizer"
+        - "storageos:key-management"
     - name: storageclass
       command:
         - "storageclass"

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -5,3 +5,5 @@ chart-dirs:
 # excluded-charts:
 #   - common
 helm-extra-args: --timeout 160s
+chart-repos:
+  - stable=https://charts.helm.sh/stable

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -181,7 +181,7 @@ main() {
 
     echo "Add git remote k8s ${CHARTS_REPO}"
     git remote add storageos "${CHARTS_REPO}" &> /dev/null || true
-    git fetch --prune --unshallow storageos master
+    git fetch storageos master
     echo
 
     # Validate manifests with kubeval.

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -54,7 +54,7 @@ install_tiller() {
     # Install Tiller with RBAC
     kubectl -n kube-system create sa tiller
     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-    docker_exec helm init --service-account tiller
+    docker_exec helm init --service-account tiller --config /workdir/test/ct.yaml
     echo "Wait for Tiller to be up and ready..."
     until kubectl -n kube-system get pods 2>&1 | grep -w "tiller-deploy"  | grep -w "1/1"; do sleep 1; done
     echo
@@ -111,7 +111,7 @@ install_kubeval() {
 # Get a list of charts that changed.
 get_changed_charts() {
     local changed_charts=("")
-    while IFS='' read -r line; do changed_charts+=("$line"); done < <(docker run --rm -v "$(pwd):/workdir" --workdir /workdir "${CHART_TESTING_IMAGE}:${CHART_TESTING_TAG}" ct list-changed --chart-dirs stable )
+    while IFS='' read -r line; do changed_charts+=("$line"); done < <(docker run --rm -v "$(pwd):/workdir" --workdir /workdir "${CHART_TESTING_IMAGE}:${CHART_TESTING_TAG}" ct list-changed --config /workdir/test/ct.yaml --chart-dirs stable )
     echo "${changed_charts[*]}"
 }
 
@@ -181,7 +181,7 @@ main() {
 
     echo "Add git remote k8s ${CHARTS_REPO}"
     git remote add storageos "${CHARTS_REPO}" &> /dev/null || true
-    git fetch storageos master
+    git fetch --prune --unshallow storageos master
     echo
 
     # Validate manifests with kubeval.


### PR DESCRIPTION
Bumps to v2.4.0.  Tested on Rancher.

Includes changes that were intended for v2.3.3 but weren't merged due to the Helm linter issue which is now resolved.